### PR TITLE
Use CMake for clang-tidy check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     needs: update_docker
     env:
       CLANG_FORMAT_BIN: clang-format-11
-      RUN_CLANG_TIDY_BIN: run-clang-tidy-11
+      CLANG_TIDY_BIN: clang-tidy-11
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -80,4 +80,4 @@ jobs:
       - name: clnag-format
         run: make clang-format
       - name: clang-tidy
-        run: make clang-tidy
+        run: make clang-tidy -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ option(GE_STATIC "Build static library" OFF)
 option(GE_DISABLE_ASSERTS "Disable asserts" OFF)
 option(GE_BUILD_EXAMPLES "Build examples" OFF)
 
+set(GE_CLANG_TIDY CACHE STRING "clang-tidy binary")
 set(GE_THIRD_PARTY_DIR ${CMAKE_SOURCE_DIR}/third-party)
 
 include(cmake/SanitizeHelpers.cmake)
@@ -51,14 +52,16 @@ else()
     message(STATUS "Asserts are enabled")
 endif()
 
+if(GE_CLANG_TIDY)
+    message(STATUS "Enable clang-tidy: ${GE_CLANG_TIDY}")
+    set(CMAKE_CXX_CLANG_TIDY ${GE_CLANG_TIDY})
+endif()
+
 # Subdirectories
 add_subdirectory(src)
+add_subdirectory(third-party)
 
 if(GE_BUILD_EXAMPLES)
     message(STATUS "Build '${CMAKE_PROJECT_NAME}' examples")
     add_subdirectory(examples)
-endif()
-
-if(NOT CMAKE_EXPORT_COMPILE_COMMANDS)
-    add_subdirectory(third-party)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CMAKE_OPTIONS       := -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DGE_STATIC=$(BUILD_STAT
                        -DGE_DISABLE_ASSERTS=$(DISABLE_ASSERTS) -DGE_BUILD_EXAMPLES=$(BUILD_EXAMPLES)
 
 CLANG_FORMAT_BIN    ?= clang-format
-RUN_CLANG_TIDY_BIN  ?= run-clang-tidy
+CLANG_TIDY_BIN      ?= clang-tidy
 
 DOCKER_IMAGE_NAME   := genesis-engine-image
 DOCKER_CMD          ?= make -j$$(nproc)
@@ -37,9 +37,8 @@ clang-format:
 	bash tools/clang_format.sh --clang-format-bin $(CLANG_FORMAT_BIN)
 
 .PHONY: clang-tidy
-clang-tidy: CMAKE_OPTIONS += -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-clang-tidy: generate_makefiles
-	$(RUN_CLANG_TIDY_BIN) -p $(BUILD_DIR)
+clang-tidy: CMAKE_OPTIONS += -DGE_CLANG_TIDY=$(CLANG_TIDY_BIN)
+clang-tidy: build_project
 
 # Docker
 .PHONY: docker_initialize

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ bash tools/clang_format.sh --fix    # Fix format
 | `DISABLE_ASSERTS` | `GE_DISABLE_ASSERTS` | `OFF` | Exclude asserts from final binary |
 | `BUILD_EXAMPLES` | `GE_BUILD_EXAMPLES` | `OFF` | Build examples |
 | `CLANG_FORMAT_BIN` | - | `clang-format` | Path to `clang-format` binary |
-| `RUN_CLANG_TIDY_BIN` | - | `run-clang-tidy` | Path to `run-clang-tidy` tool |
+| `CLANG_TIDY_BIN` | - | `clang-tidy` | Path to `clang-tidy` binary |
 | `DOCKER_CMD` | - | `make -j$(nproc)` | Command which will be executed by `make docker_run` |
 
 ### Licence

--- a/src/genesis/core/CMakeLists.txt
+++ b/src/genesis/core/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND GE_CORE_HEADERS
 )
 
 add_library(genesis-core STATIC ${GE_CORE_SRC} ${GE_CORE_HEADERS})
-target_link_libraries(genesis-core PUBLIC spdlog)
+target_link_libraries(genesis-core PUBLIC spdlog::spdlog)
 target_include_directories(genesis-core SYSTEM PUBLIC
     ${GE_THIRD_PARTY_DIR}/spdlog/include
 )

--- a/src/genesis/math/CMakeLists.txt
+++ b/src/genesis/math/CMakeLists.txt
@@ -5,7 +5,7 @@ list(APPEND GE_MATH_HEADERS
 )
 
 add_library(genesis-math INTERFACE)
-target_link_libraries(genesis-math INTERFACE glm)
+target_link_libraries(genesis-math INTERFACE glm::glm)
 target_include_directories(genesis-math SYSTEM INTERFACE
     ${GE_THIRD_PARTY_DIR}/glm
 )

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,3 +1,5 @@
+unset(CMAKE_CXX_CLANG_TIDY)
+
 # SDL2
 set(SDL_SHARED OFF CACHE BOOL "Build a shared version of the library" FORCE)
 set(SDL_STATIC ON CACHE BOOL "Build a static version of the library" FORCE)


### PR DESCRIPTION
`run-clang-tidy` was replaced with `CMAKE_CXX_CLANG_TIDY` usage.