### PR TITLE
Implement SDL2 Vulkan Render Context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
     runs-on: ubuntu-18.04
     container: hogletgames/genesis-engine:ci
     needs: update_docker
+    strategy:
+      matrix:
+        build-type: [Release, Debug]
     env:
       CLANG_FORMAT_BIN: clang-format-11
       RUN_CLANG_TIDY_BIN: run-clang-tidy-11
@@ -80,4 +83,6 @@ jobs:
       - name: clnag-format
         run: make clang-format
       - name: clang-tidy
+        env:
+          BUILD_TYPE: ${{ matrix.build-type }}
         run: make clang-tidy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ option(GE_STATIC "Build static library" OFF)
 option(GE_DISABLE_ASSERTS "Disable asserts" OFF)
 option(GE_BUILD_EXAMPLES "Build examples" OFF)
 
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    set(GE_DISABLE_DEBUG True)
+endif()
+
 include(cmake/SanitizeHelpers.cmake)
 include(cmake/Utils.cmake)
 
@@ -44,6 +48,13 @@ if(GE_DISABLE_ASSERTS)
     add_definitions(-DGE_DISABLE_ASSERTS)
 else()
     message(STATUS "Asserts are enabled")
+endif()
+
+if(GE_DISABLE_DEBUG)
+    message(STATUS "Disable debug output")
+    add_definitions(-DGE_DISABLE_DEBUG)
+else()
+    message(STATUS "Keep debug output")
 endif()
 
 # Subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
-project(genesis LANGUAGES CXX)
+project(genesis VERSION 0.0.0 LANGUAGES CXX)
 
 # CMake options
 option(GE_STATIC "Build static library" OFF)
@@ -19,6 +19,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "${CMAKE_PROJECT_NAME} version ${CMAKE_PROJECT_VERSION}")
 
 # Build options
 set(CMAKE_CXX_STANDARD 17)

--- a/examples/sdl2-vulkan/CMakeLists.txt
+++ b/examples/sdl2-vulkan/CMakeLists.txt
@@ -16,4 +16,7 @@ target_include_directories(sdl2_vulkan_example SYSTEM PRIVATE
     ${GE_THIRD_PARTY_DIR}/Vulkan/shaderc/libshaderc/include
     ${GE_THIRD_PARTY_DIR}/Vulkan/Vulkan-Headers/include
 )
+if(NOT CMAKE_EXPORT_COMPILE_COMMANDS)
+    add_dependencies(sdl2_vulkan_example VkLayer_khronos_validation-json)
+endif()
 ge_default_target_config(sdl2_vulkan_example)

--- a/include/genesis/core.h
+++ b/include/genesis/core.h
@@ -35,6 +35,7 @@
 
 #include <genesis/core/asserts.h>
 #include <genesis/core/export.h>
+#include <genesis/core/interface.h>
 #include <genesis/core/log.h>
 #include <genesis/core/memory.h>
 #include <genesis/core/utils.h>

--- a/include/genesis/core/interface.h
+++ b/include/genesis/core/interface.h
@@ -30,43 +30,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GENESIS_WINDOW_WINDOW_H_
-#define GENESIS_WINDOW_WINDOW_H_
+#ifndef GENESIS_CORE_INTERFACE_H_
+#define GENESIS_CORE_INTERFACE_H_
 
-#include <genesis/core/interface.h>
-#include <genesis/core/memory.h>
-#include <genesis/math/math.h>
-
-#include <string>
+#include <genesis/core/export.h>
 
 namespace GE {
 
-class GE_API Window: public Interface
+class GE_API Interface
 {
 public:
-    struct settings_t {
-        std::string title{TITLE_DEFAULT};
-        Vec2 size{SIZE_DEFAULT};
-        bool vsync{VSYNC_DEFAULT};
-
-        static constexpr auto TITLE_DEFAULT = "Genesis";
-        static constexpr Vec2 SIZE_DEFAULT{1280.0f, 720.0f};
-        static constexpr bool VSYNC_DEFAULT{true};
-    };
-
-    static bool initialize();
-    static void shutdown();
-
-    static Scoped<Window> create(const settings_t& settings);
-
-    virtual const Vec2& getSize() const = 0;
-    virtual void setVSync(bool enabled) = 0;
-    virtual const settings_t& getSettings() const = 0;
-
-    virtual void* getNativeWindow() = 0;
-    virtual void* getNativeContext() = 0;
+    virtual ~Interface() = default;
 };
 
 } // namespace GE
 
-#endif // GENESIS_WINDOW_WINDOW_H_
+#endif // GENESIS_CORE_INTERFACE_H_

--- a/include/genesis/core/utils.h
+++ b/include/genesis/core/utils.h
@@ -49,13 +49,13 @@ namespace GE {
 
 template<typename FromType, typename ToType>
 inline ToType toType(const std::unordered_map<FromType, ToType>& container,
-                     const FromType& from_value, ToType&& def_ret)
+                     const FromType& from_value, const ToType& def_ret)
 {
     if (auto it = container.find(from_value); it != container.end()) {
         return it->second;
     }
 
-    return std::forward<ToType>(def_ret);
+    return def_ret;
 }
 
 } // namespace GE

--- a/include/genesis/core/version.h
+++ b/include/genesis/core/version.h
@@ -30,15 +30,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GENESIS_CORE_H_
-#define GENESIS_CORE_H_
+#ifndef GENESIS_CORE_VERSION_H_
+#define GENESIS_CORE_VERSION_H_
 
-#include <genesis/core/asserts.h>
-#include <genesis/core/export.h>
-#include <genesis/core/interface.h>
-#include <genesis/core/log.h>
-#include <genesis/core/memory.h>
-#include <genesis/core/utils.h>
-#include <genesis/core/version.h>
+namespace GE {
 
-#endif // GENESIS_CORE_H_
+inline constexpr auto ENGINE_NAME = "genesis";
+
+inline constexpr uint32_t VER_MAJOR{_GE_VER_MAJOR};
+inline constexpr uint32_t VER_MINOR{_GE_VER_MINOR};
+inline constexpr uint32_t VER_PATCH{_GE_VER_PATCH};
+
+} // namespace GE
+
+#endif // GENESIS_CORE_VERSION_H_

--- a/include/genesis/renderer.h
+++ b/include/genesis/renderer.h
@@ -30,12 +30,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GENESIS_GENESIS_H_
-#define GENESIS_GENESIS_H_
+#ifndef GENESIS_RENDERER_H_
+#define GENESIS_RENDERER_H_
 
-#include <genesis/core.h>
-#include <genesis/math.h>
-#include <genesis/renderer.h>
-#include <genesis/window.h>
+#include <genesis/renderer/renderer.h>
 
-#endif // GENESIS_GENESIS_H_
+#endif // GENESIS_RENDERER_H_

--- a/include/genesis/renderer/render_context.h
+++ b/include/genesis/renderer/render_context.h
@@ -30,10 +30,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GENESIS_RENDERER_H_
-#define GENESIS_RENDERER_H_
+#ifndef GENESIS_RENDERER_RENDER_CONTEXT_H_
+#define GENESIS_RENDERER_RENDER_CONTEXT_H_
 
-#include <genesis/renderer/render_context.h>
+#include <genesis/core/interface.h>
+#include <genesis/core/memory.h>
 #include <genesis/renderer/renderer.h>
 
-#endif // GENESIS_RENDERER_H_
+namespace GE {
+
+class GE_API RenderContext: public Interface
+{
+public:
+    virtual bool initialize(void* window) = 0;
+    virtual void shutdown() = 0;
+
+    static Scoped<RenderContext> create(Renderer::API api);
+};
+
+} // namespace GE
+
+#endif // GENESIS_RENDERER_RENDER_CONTEXT_H_

--- a/include/genesis/renderer/renderer.h
+++ b/include/genesis/renderer/renderer.h
@@ -30,12 +30,43 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GENESIS_GENESIS_H_
-#define GENESIS_GENESIS_H_
+#ifndef GENESIS_RENDERER_RENDERER_H_
+#define GENESIS_RENDERER_RENDERER_H_
 
-#include <genesis/core.h>
-#include <genesis/math.h>
-#include <genesis/renderer.h>
-#include <genesis/window.h>
+#include <genesis/core/export.h>
 
-#endif // GENESIS_GENESIS_H_
+#include <string>
+
+namespace GE {
+
+class GE_API Renderer
+{
+public:
+    enum class API
+    {
+        NONE = 0,
+        VULKAN
+    };
+
+    static bool initialize(API api);
+    static void shutdown();
+
+    static API getAPI() { return get()->m_api; }
+
+private:
+    Renderer() = default;
+
+    static Renderer* get()
+    {
+        static Renderer instance;
+        return &instance;
+    }
+
+    API m_api{API::NONE};
+};
+
+std::string toString(Renderer::API api);
+
+} // namespace GE
+
+#endif // GENESIS_RENDERER_RENDERER_H_

--- a/include/genesis/window/window.h
+++ b/include/genesis/window/window.h
@@ -36,10 +36,13 @@
 #include <genesis/core/interface.h>
 #include <genesis/core/memory.h>
 #include <genesis/math/math.h>
+#include <genesis/renderer/renderer.h>
 
 #include <string>
 
 namespace GE {
+
+class RenderContext;
 
 class GE_API Window: public Interface
 {
@@ -48,10 +51,12 @@ public:
         std::string title{TITLE_DEFAULT};
         Vec2 size{SIZE_DEFAULT};
         bool vsync{VSYNC_DEFAULT};
+        Renderer::API render_api{RENDERER_API_DEFAULT};
 
         static constexpr auto TITLE_DEFAULT = "Genesis";
         static constexpr Vec2 SIZE_DEFAULT{1280.0f, 720.0f};
         static constexpr bool VSYNC_DEFAULT{true};
+        static constexpr Renderer::API RENDERER_API_DEFAULT{Renderer::API::VULKAN};
     };
 
     static bool initialize();

--- a/src/genesis/CMakeLists.txt
+++ b/src/genesis/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND GE_HEADERS
     ${GE_INCLUDE_DIR}/core.h
     ${GE_INCLUDE_DIR}/genesis.h
     ${GE_INCLUDE_DIR}/math.h
+    ${GE_INCLUDE_DIR}/renderer.h
     ${GE_INCLUDE_DIR}/window.h
 )
 
@@ -13,6 +14,7 @@ add_library(genesis ${GE_LIB_TYPE} ${GE_HEADERS})
 target_link_libraries(genesis PUBLIC
     genesis::core
     genesis::math
+    genesis::renderer
     genesis::window
 )
 ge_default_target_config(genesis)
@@ -20,4 +22,5 @@ add_library(genesis::genesis ALIAS genesis)
 
 add_subdirectory(core)
 add_subdirectory(math)
+add_subdirectory(renderer)
 add_subdirectory(window)

--- a/src/genesis/core/CMakeLists.txt
+++ b/src/genesis/core/CMakeLists.txt
@@ -11,12 +11,18 @@ list(APPEND GE_CORE_HEADERS
     ${GE_CORE_INCLUDE_DIR}/log.h
     ${GE_CORE_INCLUDE_DIR}/memory.h
     ${GE_CORE_INCLUDE_DIR}/utils.h
+    ${GE_CORE_INCLUDE_DIR}/version.h
 )
 
 add_library(genesis-core STATIC ${GE_CORE_SRC} ${GE_CORE_HEADERS})
 target_link_libraries(genesis-core PUBLIC spdlog)
 target_include_directories(genesis-core SYSTEM PUBLIC ${GE_THIRD_PARTY_DIR}/spdlog/include)
 target_include_directories(genesis-core PRIVATE ${GE_CORE_INCLUDE_DIR})
+target_compile_definitions(genesis-core PUBLIC
+    -D_GE_VER_MAJOR=${CMAKE_PROJECT_VERSION_MAJOR}
+    -D_GE_VER_MINOR=${CMAKE_PROJECT_VERSION_MINOR}
+    -D_GE_VER_PATCH=${CMAKE_PROJECT_VERSION_PATCH}
+)
 set_target_properties(genesis-core PROPERTIES POSITION_INDEPENDENT_CODE ON)
 ge_default_target_config(genesis-core)
 add_library(genesis::core ALIAS genesis-core)

--- a/src/genesis/core/CMakeLists.txt
+++ b/src/genesis/core/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND GE_CORE_SRC
 list(APPEND GE_CORE_HEADERS
     ${GE_CORE_INCLUDE_DIR}/asserts.h
     ${GE_CORE_INCLUDE_DIR}/export.h
+    ${GE_CORE_INCLUDE_DIR}/interface.h
     ${GE_CORE_INCLUDE_DIR}/log.h
     ${GE_CORE_INCLUDE_DIR}/memory.h
     ${GE_CORE_INCLUDE_DIR}/utils.h

--- a/src/genesis/renderer/CMakeLists.txt
+++ b/src/genesis/renderer/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(GE_RENDERER_INCLUDE_DIR ${GE_INCLUDE_DIR}/renderer)
+
+list(APPEND GE_RENDERER_SRC
+    renderer.cpp
+)
+
+list(APPEND GE_RENDERER_HEADERS
+    ${GE_RENDERER_INCLUDE_DIR}/renderer.h
+)
+
+add_library(genesis-renderer STATIC ${GE_RENDERER_SRC} ${GE_RENDERER_HEADERS})
+target_link_libraries(genesis-renderer PUBLIC
+    genesis::core
+)
+target_include_directories(genesis-renderer PRIVATE ${GE_RENDERER_INCLUDE_DIR})
+ge_default_target_config(genesis-renderer)
+add_library(genesis::renderer ALIAS genesis-renderer)

--- a/src/genesis/renderer/CMakeLists.txt
+++ b/src/genesis/renderer/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(GE_RENDERER_INCLUDE_DIR ${GE_INCLUDE_DIR}/renderer)
 
 list(APPEND GE_RENDERER_SRC
+    render_context.cpp
     renderer.cpp
 )
 
 list(APPEND GE_RENDERER_HEADERS
+    ${GE_RENDERER_INCLUDE_DIR}/render_context.h
     ${GE_RENDERER_INCLUDE_DIR}/renderer.h
 )
 

--- a/src/genesis/renderer/CMakeLists.txt
+++ b/src/genesis/renderer/CMakeLists.txt
@@ -13,7 +13,10 @@ list(APPEND GE_RENDERER_HEADERS
 add_library(genesis-renderer STATIC ${GE_RENDERER_SRC} ${GE_RENDERER_HEADERS})
 target_link_libraries(genesis-renderer PUBLIC
     genesis::core
+    genesis::renderer::vulkan
 )
 target_include_directories(genesis-renderer PRIVATE ${GE_RENDERER_INCLUDE_DIR})
 ge_default_target_config(genesis-renderer)
 add_library(genesis::renderer ALIAS genesis-renderer)
+
+add_subdirectory(vulkan)

--- a/src/genesis/renderer/render_context.cpp
+++ b/src/genesis/renderer/render_context.cpp
@@ -30,10 +30,22 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GENESIS_RENDERER_H_
-#define GENESIS_RENDERER_H_
+#include "render_context.h"
 
-#include <genesis/renderer/render_context.h>
-#include <genesis/renderer/renderer.h>
+#include "genesis/core/log.h"
 
-#endif // GENESIS_RENDERER_H_
+namespace GE {
+
+Scoped<RenderContext> RenderContext::create(Renderer::API api)
+{
+    switch (api) {
+        case Renderer::API::VULKAN:
+        case Renderer::API::NONE:
+        default: break;
+    }
+
+    GE_CORE_ERR("Failed to create Render Context: unsupported API '{}'", toString(api));
+    return nullptr;
+}
+
+} // namespace GE

--- a/src/genesis/renderer/renderer.cpp
+++ b/src/genesis/renderer/renderer.cpp
@@ -30,12 +30,36 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GENESIS_GENESIS_H_
-#define GENESIS_GENESIS_H_
+#include "renderer.h"
 
-#include <genesis/core.h>
-#include <genesis/math.h>
-#include <genesis/renderer.h>
-#include <genesis/window.h>
+#include "genesis/core/log.h"
+#include "genesis/core/utils.h"
 
-#endif // GENESIS_GENESIS_H_
+namespace GE {
+
+bool Renderer::initialize(Renderer::API api)
+{
+    switch (api) {
+        case Renderer::API::VULKAN: break;
+        case Renderer::API::NONE:
+        default: GE_CORE_ERR("Unknown Render API: {}", toString(api)); return false;
+    }
+
+    GE_CORE_INFO("Configuring '{}' as Renderer API", toString(api));
+
+    get()->m_api = api;
+    return true;
+}
+
+void Renderer::shutdown() {}
+
+std::string toString(Renderer::API api)
+{
+    std::string default_value = "Unknown (" + std::to_string(static_cast<int>(api)) + ")";
+    static const std::unordered_map<Renderer::API, std::string> api_to_str = {
+        {Renderer::API::NONE, "None"}, {Renderer::API::VULKAN, "Vulkan"}};
+
+    return toType(api_to_str, api, default_value);
+}
+
+} // namespace GE

--- a/src/genesis/renderer/vulkan/CMakeLists.txt
+++ b/src/genesis/renderer/vulkan/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Vulkan Renderer sources
+list(APPEND GE_RENDERER_VULKAN_SRC
+    render_context.cpp
+)
+
+list(APPEND GE_RENDERER_VULKAN_HEADERS
+    render_context.h
+    utils.h
+)
+
+# Append SDL2 sources
+list(APPEND GE_RENDERER_VULKAN_SRC sdl_render_context.cpp)
+list(APPEND GE_RENDERER_VULKAN_HEADERS sdl_render_context.h)
+
+# Vulkan Renderer library
+add_library(genesis-renderer-vulkan ${GE_RENDERER_VULKAN_SRC} ${GE_RENDERER_VULKAN_HEADERS})
+target_link_libraries(genesis-renderer-vulkan PUBLIC genesis::core)
+target_link_libraries(genesis-renderer-vulkan PRIVATE vulkan)
+target_include_directories(genesis-renderer-vulkan SYSTEM PUBLIC ${GE_THIRD_PARTY_DIR}/Vulkan/Vulkan-Headers/include)
+
+if(NOT CMAKE_EXPORT_COMPILE_COMMANDS AND NOT GE_DISABLE_DEBUG)
+    add_dependencies(genesis-renderer-vulkan VkLayer_khronos_validation-json)
+endif(${GE_THIRD_PARTY_DIR}/SDL2/include)
+
+# Add SDL2 library/include directory
+target_link_libraries(genesis-renderer-vulkan PRIVATE SDL2-static)
+target_include_directories(genesis-renderer-vulkan SYSTEM PRIVATE ${GE_THIRD_PARTY_DIR}/SDL2/include)
+
+ge_default_target_config(genesis-renderer-vulkan)
+add_library(genesis::renderer::vulkan ALIAS genesis-renderer-vulkan)

--- a/src/genesis/renderer/vulkan/render_context.cpp
+++ b/src/genesis/renderer/vulkan/render_context.cpp
@@ -1,0 +1,149 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021, Dmitry Shilnenkov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "render_context.h"
+#include "utils.h"
+
+#include "genesis/core/asserts.h"
+#include "genesis/core/version.h"
+
+namespace {
+
+constexpr int VULKAN_SEVERITY{VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT |
+                              VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+                              VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT};
+
+VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
+    VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type,
+    const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
+    [[maybe_unused]] void* user_data)
+{
+    const char* type_str = "Unknown";
+    const char* pattern = "[Vk {}]: {}";
+
+    if (type >= VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT) {
+        type_str = "Performance";
+    } else if (type >= VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT) {
+        type_str = "Validation";
+    } else if (type >= VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT) {
+        type_str = "General";
+    }
+
+    if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
+        GE_CORE_ERR(pattern, type_str, callback_data->pMessage);
+    } else if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
+        GE_CORE_WARN(pattern, type_str, callback_data->pMessage);
+    } else if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) {
+        GE_CORE_INFO(pattern, type_str, callback_data->pMessage);
+    } else if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT) {
+        GE_CORE_DBG(pattern, type_str, callback_data->pMessage);
+    } else {
+        GE_CORE_ERR("[Vk {}/Unknown]: {}", type_str, callback_data->pMessage);
+    }
+
+    return VK_FALSE;
+}
+
+VkDebugUtilsMessengerCreateInfoEXT
+getDebugMsgrCreateInfo(VkDebugUtilsMessageSeverityFlagsEXT severity)
+{
+    VkDebugUtilsMessengerCreateInfoEXT create_info{};
+    create_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+    create_info.messageSeverity = severity;
+    create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+                              VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+                              VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+    create_info.pfnUserCallback = debugCallback;
+    create_info.pUserData = nullptr;
+
+    return create_info;
+}
+
+} // namespace
+
+namespace GE::Vulkan {
+
+bool RenderContext::initialize(void* window)
+{
+    return createInstance(window) || setupDebugUtils() || createSurface(window);
+}
+
+void RenderContext::shutdown()
+{
+    destroyDebugUtilsMessengerEXT(m_instance, m_debug_utils, nullptr);
+    vkDestroyInstance(m_instance, nullptr);
+}
+
+bool RenderContext::createInstance(void* window)
+{
+    auto window_extensions = getWindowExtensions(window);
+
+    window_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+    VkApplicationInfo app_info{};
+    app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    app_info.pApplicationName = getAppName(window);
+    app_info.apiVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.pEngineName = ENGINE_NAME;
+    app_info.engineVersion = VK_MAKE_VERSION(VER_MAJOR, VER_MINOR, VER_PATCH);
+    app_info.apiVersion = VK_API_VERSION_1_2;
+
+    VkInstanceCreateInfo instance_info{};
+    instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_info.pApplicationInfo = &app_info;
+    instance_info.enabledExtensionCount = window_extensions.size();
+    instance_info.ppEnabledExtensionNames = window_extensions.data();
+
+#ifndef GE_DISABLE_DEBUG
+    auto debug_info = getDebugMsgrCreateInfo(VULKAN_SEVERITY);
+    std::array<const char*, 1> validation_layers = {"VK_LAYER_KHRONOS_validation"};
+
+    instance_info.ppEnabledLayerNames = validation_layers.data();
+    instance_info.enabledLayerCount = validation_layers.size();
+    instance_info.pNext = &debug_info;
+#endif // GE_DISABLE_DEBUG
+
+    return vkCreateInstance(&instance_info, nullptr, &m_instance) == VK_SUCCESS;
+}
+
+bool RenderContext::setupDebugUtils()
+{
+#ifdef GE_DISABLE_DEBUG
+    return true;
+#endif // GE_DISABLE_DEBUG
+
+    auto debug_info = getDebugMsgrCreateInfo(VULKAN_SEVERITY);
+    return createDebugUtilsMessengerEXT(m_instance, &debug_info, nullptr,
+                                        &m_debug_utils) == VK_SUCCESS;
+}
+
+} // namespace GE::Vulkan

--- a/src/genesis/renderer/vulkan/render_context.h
+++ b/src/genesis/renderer/vulkan/render_context.h
@@ -30,26 +30,41 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "render_context.h"
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef GENESIS_RENDERER_VULKAN_RENDER_CONTEXT_H_
+#define GENESIS_RENDERER_VULKAN_RENDER_CONTEXT_H_
 
-#include "vulkan/sdl_render_context.h"
-using VulkanPlatformContext = GE::Vulkan::SDL::RenderContext;
+#include <genesis/renderer/render_context.h>
 
-#include "genesis/core/log.h"
-#include "genesis/core/memory.h"
+#include <vulkan/vulkan.h>
 
-namespace GE {
+#include <vector>
 
-Scoped<RenderContext> RenderContext::create(Renderer::API api)
+struct SDL_Window;
+
+namespace GE::Vulkan {
+
+class RenderContext: public GE::RenderContext
 {
-    switch (api) {
-        case Renderer::API::VULKAN: return makeScoped<VulkanPlatformContext>();
-        case Renderer::API::NONE:
-        default: break;
-    }
+public:
+    bool initialize(void* window) override;
+    void shutdown() override;
 
-    GE_CORE_ERR("Failed to create Render Context: unsupported API '{}'", toString(api));
-    return nullptr;
-}
+protected:
+    virtual std::vector<const char*> getWindowExtensions(void* window) const = 0;
+    virtual const char* getAppName(void* window) const = 0;
+    virtual bool createSurface(void* window) = 0;
 
-} // namespace GE
+    VkInstance m_instance{VK_NULL_HANDLE};
+    VkSurfaceKHR m_surface{VK_NULL_HANDLE};
+
+private:
+    bool createInstance(void* window);
+    bool setupDebugUtils();
+
+    VkDebugUtilsMessengerEXT m_debug_utils{VK_NULL_HANDLE};
+};
+
+} // namespace GE::Vulkan
+
+#endif // GENESIS_RENDERER_VULKAN_RENDER_CONTEXT_H_

--- a/src/genesis/renderer/vulkan/sdl_render_context.h
+++ b/src/genesis/renderer/vulkan/sdl_render_context.h
@@ -30,26 +30,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef GENESIS_RENDERER_VULKAN_SDL_RENDER_CONTEXT_H_
+#define GENESIS_RENDERER_VULKAN_SDL_RENDER_CONTEXT_H_
+
 #include "render_context.h"
 
-#include "vulkan/sdl_render_context.h"
-using VulkanPlatformContext = GE::Vulkan::SDL::RenderContext;
+struct SDL_Window;
 
-#include "genesis/core/log.h"
-#include "genesis/core/memory.h"
+namespace GE::Vulkan::SDL {
 
-namespace GE {
-
-Scoped<RenderContext> RenderContext::create(Renderer::API api)
+class RenderContext: public GE::Vulkan::RenderContext
 {
-    switch (api) {
-        case Renderer::API::VULKAN: return makeScoped<VulkanPlatformContext>();
-        case Renderer::API::NONE:
-        default: break;
-    }
+public:
+    using GE::Vulkan::RenderContext::RenderContext;
 
-    GE_CORE_ERR("Failed to create Render Context: unsupported API '{}'", toString(api));
-    return nullptr;
-}
+private:
+    std::vector<const char*> getWindowExtensions(void* window) const override;
+    const char* getAppName(void* window) const override;
 
-} // namespace GE
+    bool createSurface(void* window) override;
+};
+
+} // namespace GE::Vulkan::SDL
+
+#endif // GENESIS_RENDERER_VULKAN_SDL_RENDER_CONTEXT_H_

--- a/src/genesis/renderer/vulkan/utils.h
+++ b/src/genesis/renderer/vulkan/utils.h
@@ -1,0 +1,85 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021, Dmitry Shilnenkov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef GENESIS_RENDERER_VULKAN_UTILS_H_
+#define GENESIS_RENDERER_VULKAN_UTILS_H_
+
+#include <vulkan/vulkan.h>
+
+#include <type_traits>
+
+namespace GE::Vulkan {
+
+template<typename FuncPFN, typename... Args>
+VkResult loadInstanceFuncAndCall(const char* func_name, VkInstance instance,
+                                 Args&&... args)
+{
+    auto* void_func = vkGetInstanceProcAddr(instance, func_name);
+
+    if (void_func == nullptr) {
+        return VK_ERROR_EXTENSION_NOT_PRESENT;
+    }
+
+    auto* func = reinterpret_cast<FuncPFN>(void_func);
+    using FuncRet = typename std::result_of<FuncPFN(VkInstance, Args...)>::type;
+    constexpr bool is_return_void = std::is_same<FuncRet, void>::value;
+
+    if constexpr (is_return_void) {
+        func(instance, std::forward<Args>(args)...);
+    } else {
+        return func(instance, std::forward<Args>(args)...);
+    }
+
+    return VK_SUCCESS;
+}
+
+inline VkResult createDebugUtilsMessengerEXT(
+    VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT* create_info,
+    const VkAllocationCallbacks* allocator, VkDebugUtilsMessengerEXT* debug_messenger)
+{
+    return loadInstanceFuncAndCall<PFN_vkCreateDebugUtilsMessengerEXT>(
+        "vkCreateDebugUtilsMessengerEXT", instance, create_info, allocator,
+        debug_messenger);
+}
+
+inline void destroyDebugUtilsMessengerEXT(VkInstance instance,
+                                          VkDebugUtilsMessengerEXT debug_messenger,
+                                          const VkAllocationCallbacks* allocator)
+{
+    loadInstanceFuncAndCall<PFN_vkDestroyDebugUtilsMessengerEXT>(
+        "vkDestroyDebugUtilsMessengerEXT", instance, debug_messenger, allocator);
+}
+
+} // namespace GE::Vulkan
+
+#endif // GENESIS_RENDERER_VULKAN_UTILS_H_

--- a/src/genesis/window/SDL/CMakeLists.txt
+++ b/src/genesis/window/SDL/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(genesis-window-sdl STATIC ${GE_WINDOW_SDL_SRC} ${GE_WINDOW_SDL_HEADE
 target_link_libraries(genesis-window-sdl PUBLIC
     genesis::core
     genesis::math
+    genesis::renderer
 )
 target_link_libraries(genesis-window-sdl PRIVATE SDL2-static)
 target_include_directories(genesis-window-sdl SYSTEM PRIVATE ${GE_THIRD_PARTY_DIR}/SDL2/include)

--- a/src/genesis/window/SDL/window.cpp
+++ b/src/genesis/window/SDL/window.cpp
@@ -33,8 +33,49 @@
 
 #include "genesis/core/asserts.h"
 #include "genesis/core/log.h"
+#include "genesis/core/utils.h"
 
 #include <SDL.h>
+
+namespace {
+
+#ifndef GE_DISABLE_DEBUG
+const char* categoryToString(int category)
+{
+    const char* default_category = "Unknown";
+    static const std::unordered_map<int, const char*> cat_to_str = {
+        {SDL_LOG_CATEGORY_APPLICATION, "App"}, {SDL_LOG_CATEGORY_ERROR, "Error"},
+        {SDL_LOG_CATEGORY_ASSERT, "Assert"},   {SDL_LOG_CATEGORY_SYSTEM, "System"},
+        {SDL_LOG_CATEGORY_AUDIO, "Audio"},     {SDL_LOG_CATEGORY_VIDEO, "Video"},
+        {SDL_LOG_CATEGORY_RENDER, "Render"},   {SDL_LOG_CATEGORY_INPUT, "Input"},
+        {SDL_LOG_CATEGORY_TEST, "Test"},       {SDL_LOG_CATEGORY_CUSTOM, "Custom"}};
+
+    return GE::toType(cat_to_str, category, default_category);
+}
+
+void debugCallback([[maybe_unused]] void* userdata, int category,
+                   SDL_LogPriority priority, const char* message)
+{
+    const char* category_str = categoryToString(category);
+    const char* pattern = "[SDL {}]: {}";
+
+    switch (priority) {
+        case SDL_LOG_PRIORITY_VERBOSE:
+            GE_CORE_TRACE(pattern, category_str, message);
+            break;
+        case SDL_LOG_PRIORITY_DEBUG: GE_CORE_DBG(pattern, category_str, message); break;
+        case SDL_LOG_PRIORITY_INFO: GE_CORE_INFO(pattern, category_str, message); break;
+        case SDL_LOG_PRIORITY_WARN: GE_CORE_WARN(pattern, category_str, message); break;
+        case SDL_LOG_PRIORITY_ERROR: GE_CORE_ERR(pattern, category_str, message); break;
+        case SDL_LOG_PRIORITY_CRITICAL:
+            GE_CORE_CRIT(pattern, category_str, message);
+            break;
+        default: GE_CORE_ERR("[SDL {}/Unknown]: {}", category_str, message); break;
+    }
+}
+#endif // GE_DISABLE_DEBUG
+
+} // namespace
 
 namespace GE::SDL {
 
@@ -62,6 +103,11 @@ Window::~Window()
 bool Window::initialize()
 {
     GE_CORE_INFO("Initializing SDL Window...");
+
+#ifndef GE_DISABLE_DEBUG
+    SDL_LogSetAllPriority(SDL_LOG_PRIORITY_INFO);
+    SDL_LogSetOutputFunction(debugCallback, nullptr);
+#endif // GE_DISABLE_DEBUG
 
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
         GE_CORE_ERR("Failed to initialize SDL: {}", SDL_GetError());

--- a/src/genesis/window/SDL/window.h
+++ b/src/genesis/window/SDL/window.h
@@ -38,6 +38,10 @@
 
 struct SDL_Window;
 
+namespace GE {
+class RenderContext;
+} // namespace GE
+
 namespace GE::SDL {
 
 class Window: public GE::Window
@@ -59,6 +63,7 @@ public:
 private:
     settings_t m_settings;
     SDL_Window* m_window{nullptr};
+    GE::Scoped<RenderContext> m_context;
 };
 
 } // namespace GE::SDL

--- a/src/genesis/window/window.cpp
+++ b/src/genesis/window/window.cpp
@@ -47,7 +47,7 @@ void Window::shutdown()
     PlatformWindow::shutdown();
 }
 
-Scoped<Window> Window::create(const settings_t &settings)
+Scoped<Window> Window::create(const settings_t& settings)
 {
     return makeScoped<PlatformWindow>(settings);
 }


### PR DESCRIPTION
- Added log callback to SDL
- Implemented skeleton of Renderer
- Implemented SDL2 Vulkan Render Context
- Added `Debug` and `Release` build for `clang-tidy` tool