### PR TITLE
Fix Renderer Context SEGFAULT

### DIFF
--- a/examples/sandbox/sandbox.cpp
+++ b/examples/sandbox/sandbox.cpp
@@ -36,14 +36,26 @@
 
 using namespace std::chrono_literals;
 
+namespace {
+
+constexpr GE::Renderer::API RENDER_API{GE::Renderer::API::VULKAN};
+
+} // namespace
+
 int main()
 {
     GE::Log::initialize();
     GE::Window::initialize();
+    GE::Renderer::initialize(RENDER_API);
 
-    auto window = GE::Window::create({});
+    GE::Window::settings_t window_settings{};
+    window_settings.render_api = RENDER_API;
+
+    auto window = GE::Window::create(window_settings);
     std::this_thread::sleep_for(10s);
+    window.reset();
 
+    GE::Renderer::shutdown();
     GE::Window::shutdown();
     GE::Log::shutdown();
 

--- a/include/genesis/core/asserts.h
+++ b/include/genesis/core/asserts.h
@@ -39,12 +39,12 @@
 #ifndef GE_DISABLE_ASSERTS
     #define GE_CORE_ASSERT(expr, ...) \
         static_cast<bool>(expr)       \
-            ? static_cast<void>(expr) \
+            ? static_cast<void>(0)    \
             : ::GE::Details::coreAssert(__FILE__, __LINE__, #expr, __VA_ARGS__)
 
-    #define GE_ASSERT(expr, ...)      \
-        static_cast<bool>(expr)       \
-            ? static_cast<void>(expr) \
+    #define GE_ASSERT(expr, ...)   \
+        static_cast<bool>(expr)    \
+            ? static_cast<void>(0) \
             : ::GE::Details::clientAssert(__FILE__, __LINE__, #expr, __VA_ARGS__)
 
 namespace GE::Details {

--- a/src/genesis/renderer/renderer.cpp
+++ b/src/genesis/renderer/renderer.cpp
@@ -39,6 +39,8 @@ namespace GE {
 
 bool Renderer::initialize(Renderer::API api)
 {
+    GE_CORE_INFO("Initializing Renderer...");
+
     switch (api) {
         case Renderer::API::VULKAN: break;
         case Renderer::API::NONE:
@@ -51,7 +53,10 @@ bool Renderer::initialize(Renderer::API api)
     return true;
 }
 
-void Renderer::shutdown() {}
+void Renderer::shutdown()
+{
+    GE_CORE_INFO("Shutdown Renderer");
+}
 
 Renderer::API toRendererAPI(const std::string& api_str)
 {

--- a/src/genesis/renderer/vulkan/render_context.cpp
+++ b/src/genesis/renderer/vulkan/render_context.cpp
@@ -94,12 +94,14 @@ namespace GE::Vulkan {
 
 bool RenderContext::initialize(void* window)
 {
-    return createInstance(window) || setupDebugUtils() || createSurface(window);
+    return createInstance(window) && setupDebugUtils() && createSurface(window);
 }
 
 void RenderContext::shutdown()
 {
+#ifndef GE_DISABLE_DEBUG
     destroyDebugUtilsMessengerEXT(m_instance, m_debug_utils, nullptr);
+#endif // GE_DISABLE_DEBUG
     vkDestroyInstance(m_instance, nullptr);
 }
 
@@ -107,7 +109,9 @@ bool RenderContext::createInstance(void* window)
 {
     auto window_extensions = getWindowExtensions(window);
 
+#ifndef GE_DISABLE_DEBUG
     window_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+#endif // GE_DISABLE_DEBUG
 
     VkApplicationInfo app_info{};
     app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;

--- a/src/genesis/renderer/vulkan/render_context.cpp
+++ b/src/genesis/renderer/vulkan/render_context.cpp
@@ -94,11 +94,13 @@ namespace GE::Vulkan {
 
 bool RenderContext::initialize(void* window)
 {
+    GE_CORE_INFO("Initializing Vulkan Context...");
     return createInstance(window) && setupDebugUtils() && createSurface(window);
 }
 
 void RenderContext::shutdown()
 {
+    GE_CORE_INFO("Shutdown Vulkan Context");
 #ifndef GE_DISABLE_DEBUG
     destroyDebugUtilsMessengerEXT(m_instance, m_debug_utils, nullptr);
 #endif // GE_DISABLE_DEBUG

--- a/src/genesis/window/SDL/window.cpp
+++ b/src/genesis/window/SDL/window.cpp
@@ -140,7 +140,7 @@ bool Window::initialize()
 
 void Window::shutdown()
 {
-    GE_CORE_INFO("Shutting down SDL Window...");
+    GE_CORE_INFO("Shutdown SDL Window");
     SDL_Quit();
 }
 


### PR DESCRIPTION
- FIx debug initialization in Render Context
- Fix double call expression in Assert
- Added verbose output for `initialize()` / `shutdown()` methods