### PR TITLE
Use gcc-11/g++-11 to build project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
           - build-type: TSAN
             disable-asserts: OFF
     env:
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc
+      CXX: g++
       BUILD_TYPE: ${{ matrix.build-type }}
       DISABLE_ASSERTS: ${{ matrix.disable-asserts }}
       BUILD_TESTS: ON
@@ -74,16 +74,13 @@ jobs:
     strategy:
       matrix:
         build-type: [Release, Debug]
-    env:
-      CLANG_FORMAT_BIN: clang-format-11
-      RUN_CLANG_TIDY_BIN: run-clang-tidy-11
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: clnag-format
+      - name: clang-format
         run: make clang-format
       - name: clang-tidy
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,11 @@ RUN apt-get install -y libx11-dev libsamplerate-dev libasound2-dev \
 RUN apt-get install -y libwayland-dev
 
 # Compilers
+ENV GCC_VERSION=11
 RUN apt-add-repository ppa:ubuntu-toolchain-r/test && \
-    apt-get update && apt-get install -y gcc-10 g++-10 && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100 && \
+    apt-get update && apt-get install -y gcc-${GCC_VERSION} g++-${GCC_VERSION} && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} ${GCC_VERSION}0 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} ${GCC_VERSION}0 && \
     update-alternatives --config gcc && \
     update-alternatives --config g++
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,15 @@ RUN apt-get install -y libwayland-dev
 # Compilers
 ENV GCC_VERSION=11
 RUN apt-add-repository ppa:ubuntu-toolchain-r/test && \
-    apt-get update && apt-get install -y gcc-${GCC_VERSION} g++-${GCC_VERSION} && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} ${GCC_VERSION}0 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} ${GCC_VERSION}0 && \
-    update-alternatives --config gcc && \
-    update-alternatives --config g++
+    apt-get update && apt-get install -y gcc-${GCC_VERSION} g++-${GCC_VERSION}
 
-# Test tools
+# Clang tools
 ENV CLANG_VERSION=11
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${CLANG_VERSION} main" && \
     apt-get update && apt-get install -y clang-format-${CLANG_VERSION} clang-tidy-${CLANG_VERSION}
+
+# Update alternatives
+COPY tools/update_alternatives_gcc.sh tools/update_alternatives_clang.sh /tmp/
+RUN /tmp/update_alternatives_gcc.sh "${GCC_VERSION}" "${GCC_VERSION}0" && \
+    /tmp/update_alternatives_clang.sh "${CLANG_VERSION}" "${CLANG_VERSION}0"

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ docker_cleanup:
 .PHONY: docker_run
 docker_run:
 	docker run --rm \
-		-t \
+		-ti \
 		-v $(PWD):$(PWD) \
 		-w $(PWD) \
-		-u $$(id -u):$(id -g) \
+		-u $$(id -u):$$(id -g) \
 		-e CMAKE_OPTIONS="$(CMAKE_OPTIONS)" \
 		-e CLANG_FORMAT_BIN="clang-format-11" \
 		-e RUN_CLANG_TIDY_BIN="run-clang-tidy-11" \

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ docker_initialize:
 
 .PHONY: docker_cleenup
 docker_cleanup:
-	docker rm $(DOCKER_IMAGE_NAME)
+	docker image rm -f $(DOCKER_IMAGE_NAME)
 
 .PHONY: docker_run
 docker_run:

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -30,3 +30,4 @@ add_subdirectory(magic_enum)
 
 # googletest
 add_subdirectory(googletest)
+target_compile_options(gtest PRIVATE -Wno-error=maybe-uninitialized)

--- a/third-party/Vulkan/CMakeLists.txt
+++ b/third-party/Vulkan/CMakeLists.txt
@@ -1,7 +1,9 @@
+# Build options
 set(ENABLE_CTEST        OFF CACHE BOOL "Enable glslang tests" FORCE)
 set(SHADERC_SKIP_TESTS  ON  CACHE BOOL "Skip shaderc tests" FORCE)
 set(SPIRV_SKIP_TESTS    ON  CACHE BOOL "Skip SPIRV tests" FORCE)
 
+# Submodules
 add_subdirectory(Vulkan-Headers)
 add_subdirectory(Vulkan-Loader)
 add_subdirectory(glslang)
@@ -9,5 +11,13 @@ add_subdirectory(SPIRV-Headers)
 add_subdirectory(SPIRV-Tools)
 add_subdirectory(Vulkan-ValidationLayers)
 add_subdirectory(shaderc)
+
+# Compile options
+list(APPEND SPIRV_TOOLS_TARGETS SPIRV-Tools-static SPIRV-Tools-shared)
+
+foreach(SPIRV_TOOLS_TARGET IN LISTS SPIRV_TOOLS_TARGETS)
+    target_compile_options(${SPIRV_TOOLS_TARGET} PRIVATE
+        $<$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,8.0.0>:-Wno-error=stringop-truncation>)
+endforeach()
 
 target_compile_options(shaderc_util PRIVATE $<$<CONFIG:USAN>:-fno-sanitize=vptr>)

--- a/tools/update_alternatives_clang.sh
+++ b/tools/update_alternatives_clang.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+VERSION=${1}
+PRIORITY=${2}
+
+USAGE="${0} <version> <priority>"
+
+if [ -z "${VERSION}" ] || [ -z "${PRIORITY}" ]; then
+    echo "${USAGE}"
+    exit 1
+fi
+
+update-alternatives \
+    --install /usr/bin/clang          clang          /usr/bin/clang-${VERSION}   ${PRIORITY} \
+    --slave   /usr/bin/clang++        clang++        /usr/bin/clang++-${VERSION} \
+    --slave   /usr/bin/clang-format   clang-format   /usr/bin/clang-format-${VERSION} \
+    --slave   /usr/bin/clang-tidy     clang-tidy     /usr/bin/clang-tidy-${VERSION} \
+    --slave   /usr/bin/run-clang-tidy run-clang-tidy /usr/bin/run-clang-tidy-${VERSION}
+
+update-alternatives --config clang

--- a/tools/update_alternatives_gcc.sh
+++ b/tools/update_alternatives_gcc.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+VERSION=${1}
+PRIORITY=${2}
+
+USAGE="${0} <version> <priority>"
+
+if [ -z "${VERSION}" ] || [ -z "${PRIORITY}" ]; then
+    echo "${USAGE}"
+    exit 1
+fi
+
+update-alternatives \
+    --install /usr/bin/gcc gcc /usr/bin/gcc-${VERSION} ${PRIORITY} \
+    --slave   /usr/bin/g++ g++ /usr/bin/g++-${VERSION}
+
+update-alternatives --config gcc


### PR DESCRIPTION
- Replaced `gcc-10`/`g++-10` with `gcc-11`/g++-11` in Dockerfile
- Disabled `stringop-truncation` error in Vulkan SDK for `gcc` >= 8
- Added scripts to update `gcc` and `clang` alternatives