### PR TITLE
Implement the common formatter for user-defined types

### DIFF
--- a/include/genesis/core.h
+++ b/include/genesis/core.h
@@ -40,6 +40,7 @@
 #include <genesis/core/export.h>
 #include <genesis/core/filesystem.h>
 #include <genesis/core/format.h>
+#include <genesis/core/format_user_type.h>
 #include <genesis/core/interface.h>
 #include <genesis/core/log.h>
 #include <genesis/core/memory.h>

--- a/include/genesis/core/enum.h
+++ b/include/genesis/core/enum.h
@@ -32,7 +32,6 @@
 
 #pragma once
 
-#include <fmt/format.h>
 #include <magic_enum.hpp>
 
 #define GE_EXTEND_ENUM_RANGE(enum_type, min_value, max_value)  \
@@ -45,9 +44,12 @@
     } // namespace magic_enum::customize
 
 namespace GE {
+namespace Details {
 
 template<typename T, typename Ret = void>
 using EnableIfIsEnum = std::enable_if_t<std::is_enum_v<T>, Ret>;
+
+} // namespace Details
 
 using magic_enum::bitwise_operators::operator~;
 using magic_enum::bitwise_operators::operator|;
@@ -57,24 +59,16 @@ using magic_enum::bitwise_operators::operator|=;
 using magic_enum::bitwise_operators::operator&=;
 using magic_enum::bitwise_operators::operator^=;
 
-template<typename EnumType, typename = EnableIfIsEnum<EnumType>>
+template<typename EnumType, typename = Details::EnableIfIsEnum<EnumType>>
 std::string toString(EnumType value)
 {
     return std::string{magic_enum::enum_name(value)};
 }
 
 template<typename EnumType>
-std::optional<EnumType> toEnum(const std::string& string)
+std::optional<EnumType> toEnum(std::string_view string)
 {
     return magic_enum::enum_cast<EnumType>(string);
 }
 
 } // namespace GE
-
-template<typename EnumType>
-struct fmt::formatter<EnumType, GE::EnableIfIsEnum<EnumType, char>>: fmt::formatter<std::string> {
-    auto format(EnumType value, fmt::format_context& ctx) -> decltype(ctx.out())
-    {
-        return format_to(ctx.out(), "{}", GE::toString(value));
-    }
-};

--- a/include/genesis/core/log.h
+++ b/include/genesis/core/log.h
@@ -32,10 +32,8 @@
 
 #pragma once
 
-#include <genesis/core/enum.h>
 #include <genesis/core/export.h>
 
-#include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
 
 #include <memory>
@@ -155,6 +153,6 @@ private:
     Logger m_client_logger;
 };
 
-Logger::Level toLoggerLevel(const std::string& level_str);
+Logger::Level toLoggerLevel(std::string_view level_str);
 
 } // namespace GE

--- a/include/genesis/window/events/event.h
+++ b/include/genesis/window/events/event.h
@@ -62,10 +62,9 @@ private:
     bool m_handled{false};
 };
 
-template<typename OStream>
-OStream& operator<<(OStream& os, const Event& event)
+inline std::string toString(const Event& event)
 {
-    return os << event.asString();
+    return event.asString();
 }
 
 } // namespace GE

--- a/src/genesis/core/CMakeLists.txt
+++ b/src/genesis/core/CMakeLists.txt
@@ -12,6 +12,7 @@ list(APPEND CORE_HEADERS
     ${INCLUDE_DIR}/export.h
     ${INCLUDE_DIR}/filesystem.h
     ${INCLUDE_DIR}/format.h
+    ${INCLUDE_DIR}/format_user_type.h
     ${INCLUDE_DIR}/hash.h
     ${INCLUDE_DIR}/interface.h
     ${INCLUDE_DIR}/log.h

--- a/src/genesis/core/log.cpp
+++ b/src/genesis/core/log.cpp
@@ -32,6 +32,8 @@
 
 #include "log.h"
 #include "asserts.h"
+#include "enum.h"
+#include "format_user_type.h"
 
 #include <spdlog/sinks/stdout_color_sinks.h>
 
@@ -117,7 +119,7 @@ void Log::shutdown()
     get()->m_core_logger.shutdown();
 }
 
-Logger::Level toLoggerLevel(const std::string& level_str)
+Logger::Level toLoggerLevel(std::string_view level_str)
 {
     auto level = toEnum<Logger::Level>(level_str);
     return level.has_value() ? level.value() : Logger::Level::UNKNOWN;

--- a/src/genesis/graphics/graphics.cpp
+++ b/src/genesis/graphics/graphics.cpp
@@ -41,7 +41,7 @@ namespace GE {
 
 bool Graphics::initialize(const Graphics::settings_t& settings, void* window)
 {
-    GE_CORE_INFO("Initializing Graphics, API: {}", toString(settings.api));
+    GE_CORE_INFO("Initializing Graphics, API: {}", settings.api);
     auto& context = get()->m_context;
 
     switch (settings.api) {

--- a/src/genesis/graphics/graphics.cpp
+++ b/src/genesis/graphics/graphics.cpp
@@ -35,6 +35,7 @@
 #include "vulkan/graphics_context.h"
 
 #include "genesis/core/enum.h"
+#include "genesis/core/format_user_type.h"
 
 namespace GE {
 

--- a/src/genesis/graphics/shader_precompiler.cpp
+++ b/src/genesis/graphics/shader_precompiler.cpp
@@ -32,7 +32,9 @@
 
 #include "shader_precompiler.h"
 
+#include "genesis/core/enum.h"
 #include "genesis/core/filesystem.h"
+#include "genesis/core/format_user_type.h"
 #include "genesis/core/log.h"
 
 #include <shaderc/shaderc.hpp>

--- a/src/genesis/graphics/vulkan/pipeline_barrier.cpp
+++ b/src/genesis/graphics/vulkan/pipeline_barrier.cpp
@@ -64,7 +64,7 @@ std::pair<VkAccessFlags, VkAccessFlags> undefinedToVkAccess(VkImageLayout new_la
         default: break;
     }
 
-    GE_ASSERT(false, "Unsupported layout: {}", GE::toString(new_layout));
+    GE_ASSERT(false, "Unsupported layout: {}", new_layout);
     return {};
 }
 
@@ -76,7 +76,7 @@ std::pair<VkAccessFlags, VkAccessFlags> generalToVkAccess(VkImageLayout new_layo
         default: break;
     }
 
-    GE_ASSERT(false, "Unsupported layout: {}", GE::toString(new_layout));
+    GE_ASSERT(false, "Unsupported layout: {}", new_layout);
     return {};
 }
 
@@ -88,7 +88,7 @@ std::pair<VkAccessFlags, VkAccessFlags> transferSrcToVkAccess(VkImageLayout new_
         default: break;
     }
 
-    GE_ASSERT(false, "Unsupported layout: {}", GE::toString(new_layout));
+    GE_ASSERT(false, "Unsupported layout: {}", new_layout);
     return {};
 }
 
@@ -101,7 +101,7 @@ std::pair<VkAccessFlags, VkAccessFlags> transferDstToVkAccess(VkImageLayout new_
         default: break;
     }
 
-    GE_ASSERT(false, "Unsupported layout: {}", GE::toString(new_layout));
+    GE_ASSERT(false, "Unsupported layout: {}", new_layout);
     return {};
 }
 
@@ -115,7 +115,7 @@ std::pair<VkAccessFlags, VkAccessFlags> depthStencilToVkAccess(VkImageLayout new
         default: break;
     }
 
-    GE_ASSERT(false, "Unsupported layout: {}", GE::toString(new_layout));
+    GE_ASSERT(false, "Unsupported layout: {}", new_layout);
     return {};
 }
 
@@ -126,7 +126,7 @@ std::pair<VkAccessFlags, VkAccessFlags> shaderReadOnlyToVkAccess(VkImageLayout n
         default: break;
     }
 
-    GE_ASSERT(false, "Unsupported layout: {}", GE::toString(new_layout));
+    GE_ASSERT(false, "Unsupported layout: {}", new_layout);
     return {};
 }
 
@@ -144,7 +144,7 @@ std::pair<VkAccessFlags, VkAccessFlags> toVkAccess(VkImageLayout old_layout,
         default: break;
     }
 
-    GE_ASSERT(false, "Unsupported layout: {}", GE::toString(old_layout));
+    GE_ASSERT(false, "Unsupported layout: {}", old_layout);
     return {};
 };
 

--- a/src/genesis/graphics/vulkan/pipeline_barrier.cpp
+++ b/src/genesis/graphics/vulkan/pipeline_barrier.cpp
@@ -31,9 +31,10 @@
  */
 
 #include "pipeline_barrier.h"
-#include "image.h"
 
 #include "genesis/core/asserts.h"
+#include "genesis/core/enum.h"
+#include "genesis/core/format_user_type.h"
 
 namespace {
 

--- a/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
+++ b/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
@@ -39,9 +39,10 @@
 #include "vulkan_exception.h"
 
 #include "genesis/core/enum.h"
+#include "genesis/core/format.h"
+#include "genesis/core/format_user_type.h"
 #include "genesis/core/log.h"
 #include "genesis/core/utils.h"
-#include "genesis/graphics/render_command.h"
 #include "genesis/window/events/event_dispatcher.h"
 #include "genesis/window/events/window_events.h"
 

--- a/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
+++ b/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
@@ -87,7 +87,7 @@ bool WindowRenderer::beginFrame(ClearMode clear_mode)
     }
 
     if (acquire_result != VK_SUCCESS && acquire_result != VK_SUBOPTIMAL_KHR) {
-        GE_CORE_ERR("Failed to acquire Swap Chain image: {}", toString(acquire_result));
+        GE_CORE_ERR("Failed to acquire Swap Chain image: {}", acquire_result);
         return false;
     }
 

--- a/src/genesis/graphics/vulkan/swap_chain.cpp
+++ b/src/genesis/graphics/vulkan/swap_chain.cpp
@@ -37,6 +37,7 @@
 #include "vulkan_exception.h"
 
 #include "genesis/core/enum.h"
+#include "genesis/core/format_user_type.h"
 #include "genesis/core/log.h"
 
 namespace {

--- a/src/genesis/graphics/vulkan/swap_chain.cpp
+++ b/src/genesis/graphics/vulkan/swap_chain.cpp
@@ -138,7 +138,7 @@ VkResult SwapChain::submitCommandBuffer(VkCommandBuffer* command_buffer)
     if (auto submit_result = vkQueueSubmit(m_device->graphicsQueue(), 1, &submit_info,
                                            m_in_flight_fences[m_current_frame]);
         submit_result != VK_SUCCESS) {
-        GE_CORE_ERR("Failed to submit Draw Command Buffer: {}", toString(submit_result));
+        GE_CORE_ERR("Failed to submit Draw Command Buffer: {}", submit_result);
         return submit_result;
     }
 

--- a/src/genesis/window/SDL/window.cpp
+++ b/src/genesis/window/SDL/window.cpp
@@ -32,8 +32,10 @@
 
 #include "window.h"
 
+#include "genesis/core/enum.h"
 #include "genesis/core/exception.h"
 #include "genesis/core/format.h"
+#include "genesis/core/format_user_type.h"
 #include "genesis/core/log.h"
 #include "genesis/core/utils.h"
 #include "genesis/window/events/key_events.h"

--- a/src/genesis/window/events/key_events.cpp
+++ b/src/genesis/window/events/key_events.cpp
@@ -49,7 +49,7 @@ KeyPressedEvent::KeyPressedEvent(KeyCode code, KeyModFlags mod, uint32_t repeat_
 
 std::string KeyPressedEvent::asString() const
 {
-    return GE_FMTSTR("KeyPressedEvent: Key: '{}', Mod: '{:#010b}' ({})", toString(m_code),
+    return GE_FMTSTR("KeyPressedEvent: Key: '{}', Mod: '{:#010b}' ({})", m_code,
                      static_cast<uint8_t>(m_mod), m_repeat_count);
 }
 
@@ -59,7 +59,7 @@ KeyReleasedEvent::KeyReleasedEvent(KeyCode code, KeyModFlags mod)
 
 std::string KeyReleasedEvent::asString() const
 {
-    return GE_FMTSTR("KeyReleasedEvent: Key: '{}', Mod: '{:#010b}'", toString(m_code),
+    return GE_FMTSTR("KeyReleasedEvent: Key: '{}', Mod: '{:#010b}'", m_code,
                      static_cast<uint8_t>(m_mod));
 }
 

--- a/src/genesis/window/events/mouse_events.cpp
+++ b/src/genesis/window/events/mouse_events.cpp
@@ -44,7 +44,7 @@ MouseMovedEvent::MouseMovedEvent(const Vec2& position, uint32_t window_id)
 
 std::string MouseMovedEvent::asString() const
 {
-    return GE_FMTSTR("MouseMovedEvent: {}", toString(m_position));
+    return GE_FMTSTR("MouseMovedEvent: {}", m_position);
 }
 
 MouseScrolledEvent::MouseScrolledEvent(const Vec2& offset)
@@ -53,7 +53,7 @@ MouseScrolledEvent::MouseScrolledEvent(const Vec2& offset)
 
 std::string MouseScrolledEvent::asString() const
 {
-    return GE_FMTSTR("MouseScrolledEvent: {}", toString(m_offset));
+    return GE_FMTSTR("MouseScrolledEvent: {}", m_offset);
 }
 
 MouseButtonEvent::MouseButtonEvent(MouseButton button)
@@ -66,7 +66,7 @@ MouseButtonPressedEvent::MouseButtonPressedEvent(MouseButton button)
 
 std::string MouseButtonPressedEvent::asString() const
 {
-    return GE_FMTSTR("MouseButtonPressedEvent: {}", toString(m_button));
+    return GE_FMTSTR("MouseButtonPressedEvent: {}", m_button);
 }
 
 MouseButtonReleasedEvent::MouseButtonReleasedEvent(MouseButton button)
@@ -75,7 +75,7 @@ MouseButtonReleasedEvent::MouseButtonReleasedEvent(MouseButton button)
 
 std::string MouseButtonReleasedEvent::asString() const
 {
-    return GE_FMTSTR("MouseButtonReleasedEvent: {}", toString(m_button));
+    return GE_FMTSTR("MouseButtonReleasedEvent: {}", m_button);
 }
 
 } // namespace GE

--- a/src/genesis/window/events/mouse_events.cpp
+++ b/src/genesis/window/events/mouse_events.cpp
@@ -33,6 +33,7 @@
 #include "mouse_events.h"
 
 #include "genesis/core/format.h"
+#include "genesis/core/format_user_type.h"
 
 namespace GE {
 

--- a/src/genesis/window/events/window_events.cpp
+++ b/src/genesis/window/events/window_events.cpp
@@ -33,6 +33,7 @@
 #include "window_events.h"
 
 #include "genesis/core/format.h"
+#include "genesis/core/format_user_type.h"
 
 namespace GE {
 

--- a/src/genesis/window/events/window_events.cpp
+++ b/src/genesis/window/events/window_events.cpp
@@ -48,7 +48,7 @@ WindowMovedEvent::WindowMovedEvent(uint32_t id, Vec2 position)
 
 std::string WindowMovedEvent::asString() const
 {
-    return GE_FMTSTR("WindowMovedEvent: {}", toString(m_position));
+    return GE_FMTSTR("WindowMovedEvent: {}", m_position);
 }
 
 WindowResizedEvent::WindowResizedEvent(uint32_t id, const Vec2& size)
@@ -58,7 +58,7 @@ WindowResizedEvent::WindowResizedEvent(uint32_t id, const Vec2& size)
 
 std::string WindowResizedEvent::asString() const
 {
-    return GE_FMTSTR("WindowResizedEvent: {}", toString(m_size));
+    return GE_FMTSTR("WindowResizedEvent: {}", m_size);
 }
 
 std::string WindowMinimizedEvent::asString() const

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -22,7 +22,7 @@ set(DEPS_DIR ${FETCHCONTENT_BASE_DIR})
 # fmt
 FetchContent_Declare(fmt
     GIT_REPOSITORY https://github.com/hogletgames/fmt.git
-    GIT_TAG 9.1.0)
+    GIT_TAG 10.0.0)
 FetchContent_MakeAvailable(fmt)
 
 # glm
@@ -52,7 +52,7 @@ FetchContent_MakeAvailable(SDL2)
 # spdlog
 FetchContent_Declare(spdlog
     GIT_REPOSITORY https://github.com/hogletgames/spdlog.git
-    GIT_TAG v1.11.0)
+    GIT_TAG v1.12.0)
 FetchContent_MakeAvailable(spdlog)
 
 # imgui


### PR DESCRIPTION
The formatter assumes that there is the `GE::toString(Type value)` function and uses it to get a string representation of the type.