### PR TITLE
Implement Weighted-Blended OIT scene rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build docker image
         uses: whoan/docker-build-with-cache-action@v6
         with:
@@ -46,9 +46,9 @@ jobs:
       BUILD_TESTS: ON
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ matrix.build-type }}-${{ hashFiles('third-party/CMakeLists.txt') }}
           path: build/_deps
@@ -70,9 +70,9 @@ jobs:
       BUILD_EXAMPLES: ON
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ matrix.build-type }}-${{ hashFiles('third-party/CMakeLists.txt') }}
           path: build/_deps

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ build/examples/sandbox/sandbox -e gui
 
 ```bash
 export VK_LAYER_PATH=build/_deps/vulkan-validationlayers-build/layers
-export VK_ICD_FILENAMES=build/_deps/moltenvk-src/Package/Release/MoltenVK/dylib/macOS/MoltenVK_icd.json
+export VK_ICD_FILENAMES=build/_deps/moltenvk-src/Package/Latest/MoltenVK/dynamic/dylib/macOS/MoltenVK_icd.json
 build/examples/sandbox/sandbox -e gui
 ```
 

--- a/apps/level-editor/gui/panels/assets_panel.cpp
+++ b/apps/level-editor/gui/panels/assets_panel.cpp
@@ -208,6 +208,7 @@ void AssetsPanel::visit(GE::Assets::TextureResource *resource)
 
     Text::call("Use count: %d", resource->texture().use_count());
     Text::call("Filepath: %s", resource->filepath().c_str());
+    Text::call("Is opaque: %s", toString(resource->texture()->isOpaque()).data());
     Image::call(texture->nativeID(), scaledTextureSize(texture->size(), m_window_size.x));
 }
 

--- a/apps/level-editor/level_editor.cpp
+++ b/apps/level-editor/level_editor.cpp
@@ -69,8 +69,8 @@ bool LevelEditor::initialize()
         return false;
     }
 
-    m_scene_renderer =
-        GE::makeScoped<GE::Scene::PlainRenderer>(m_ctx.cameraController()->camera().get());
+    createSceneRenderer();
+
     m_gui = GE::makeScoped<LevelEditorGUI>(&m_ctx);
     connectSignals();
     initializeProject();
@@ -94,12 +94,9 @@ void LevelEditor::onEvent(GE::Event* event)
 
 void LevelEditor::onRender()
 {
-    auto* renderer = m_ctx.sceneFbo()->renderer();
-    auto* scene = m_ctx.scene();
-
     updateParameters();
 
-    m_scene_renderer->render(renderer, *scene);
+    m_ctx.sceneRenderer()->render(*m_ctx.scene());
     m_gui->onRender();
 }
 
@@ -112,6 +109,14 @@ bool LevelEditor::createFramebuffer()
 
     m_ctx.sceneFbo() = GE::Framebuffer::create(model_fbo_config);
     return m_ctx.sceneFbo() != nullptr;
+}
+
+void LevelEditor::createSceneRenderer()
+{
+    auto* renderer = m_ctx.sceneFbo()->renderer();
+    const auto* camera = m_ctx.cameraController()->camera().get();
+
+    m_ctx.sceneRenderer() = GE::makeScoped<GE::Scene::PlainRenderer>(renderer, camera);
 }
 
 void LevelEditor::connectSignals()

--- a/apps/level-editor/level_editor.cpp
+++ b/apps/level-editor/level_editor.cpp
@@ -70,7 +70,7 @@ bool LevelEditor::initialize()
     }
 
     m_scene_renderer =
-        GE::makeScoped<GE::Scene::Renderer>(m_ctx.cameraController()->camera().get());
+        GE::makeScoped<GE::Scene::PlainRenderer>(m_ctx.cameraController()->camera().get());
     m_gui = GE::makeScoped<LevelEditorGUI>(&m_ctx);
     connectSignals();
     initializeProject();
@@ -99,10 +99,7 @@ void LevelEditor::onRender()
 
     updateParameters();
 
-    renderer->beginFrame();
     m_scene_renderer->render(renderer, *scene);
-    renderer->endFrame();
-
     m_gui->onRender();
 }
 

--- a/apps/level-editor/level_editor.cpp
+++ b/apps/level-editor/level_editor.cpp
@@ -103,7 +103,7 @@ void LevelEditor::onRender()
 bool LevelEditor::createFramebuffer()
 {
     GE::Framebuffer::config_t model_fbo_config{};
-    model_fbo_config.clear_color = {0.3f, 0.3f, 0.3f, 1.0f};
+    model_fbo_config.attachments[0].clear_color = {0.3f, 0.3f, 0.3f, 1.0f};
     model_fbo_config.size = {720.0f, 480.0f};
     model_fbo_config.msaa_samples = GE::Graphics::limits().max_msaa;
 

--- a/apps/level-editor/level_editor.cpp
+++ b/apps/level-editor/level_editor.cpp
@@ -116,7 +116,7 @@ void LevelEditor::createSceneRenderer()
     auto* renderer = m_ctx.sceneFbo()->renderer();
     const auto* camera = m_ctx.cameraController()->camera().get();
 
-    m_ctx.sceneRenderer() = GE::makeScoped<GE::Scene::PlainRenderer>(renderer, camera);
+    m_ctx.sceneRenderer() = GE::makeScoped<GE::Scene::WeightedBlendedOITRenderer>(renderer, camera);
 }
 
 void LevelEditor::connectSignals()

--- a/apps/level-editor/level_editor.h
+++ b/apps/level-editor/level_editor.h
@@ -34,7 +34,6 @@
 
 #include "level_editor_context.h"
 
-#include <genesis/assets/registry.h>
 #include <genesis/core/export.h>
 #include <genesis/core/timestamp.h>
 #include <genesis/graphics/framebuffer.h>
@@ -87,7 +86,7 @@ private:
 
     LevelEditorContext m_ctx;
     GE::Scoped<LevelEditorGUI> m_gui;
-    GE::Scoped<GE::Scene::Renderer> m_scene_renderer;
+    GE::Scoped<GE::Scene::PlainRenderer> m_scene_renderer;
 
     GE::Vec2 m_viewport{1.0f, 1.0f};
 };

--- a/apps/level-editor/level_editor.h
+++ b/apps/level-editor/level_editor.h
@@ -63,6 +63,7 @@ public:
 
 private:
     bool createFramebuffer();
+    void createSceneRenderer();
     void connectSignals();
     void initializeProject();
 
@@ -86,7 +87,6 @@ private:
 
     LevelEditorContext m_ctx;
     GE::Scoped<LevelEditorGUI> m_gui;
-    GE::Scoped<GE::Scene::PlainRenderer> m_scene_renderer;
 
     GE::Vec2 m_viewport{1.0f, 1.0f};
 };

--- a/apps/level-editor/level_editor_context.h
+++ b/apps/level-editor/level_editor_context.h
@@ -38,6 +38,7 @@
 #include <genesis/core/memory.h>
 #include <genesis/scene/camera/view_projection_camera.h>
 #include <genesis/scene/camera/vp_camera_controller.h>
+#include <genesis/scene/renderer.h>
 #include <genesis/scene/scene.h>
 
 namespace GE {
@@ -51,6 +52,7 @@ class GE_API LevelEditorContext
 public:
     Settings* settings() { return m_settings.get(); }
     GE::Scoped<GE::Framebuffer>& sceneFbo() { return m_scene_fbo; }
+    GE::Scoped<GE::Scene::IRenderer>& sceneRenderer() { return m_scene_renderer; }
     GE::Assets::Registry* assets() { return &m_assets; }
     GE::Scene::Scene* scene() { return &m_scene; }
     GE::Scene::VPCameraController* cameraController() { return &m_camera_controller; }
@@ -61,6 +63,7 @@ public:
 private:
     GE::Scoped<Settings> m_settings{GE::makeScoped<Settings>()};
     GE::Scoped<GE::Framebuffer> m_scene_fbo;
+    GE::Scoped<GE::Scene::IRenderer> m_scene_renderer;
     GE::Assets::Registry m_assets;
     GE::Scene::Scene m_scene;
     GE::Shared<GE::Scene::ViewProjectionCamera> m_camera{

--- a/examples/sandbox/drawable/drawable.cpp
+++ b/examples/sandbox/drawable/drawable.cpp
@@ -63,7 +63,7 @@ void Drawable::bind(Renderer *renderer, const mvp_t &mvp)
     m_mpv->setData(sizeof(mvp_t), &mvp);
 
     renderer->command()->bind(m_pipeline.get());
-    renderer->command()->bind(m_pipeline.get(), "MVP", m_mpv.get());
+    renderer->command()->bind(m_pipeline.get(), "MVP", *m_mpv);
 }
 
 } // namespace GE::Examples

--- a/examples/sandbox/drawable/model.cpp
+++ b/examples/sandbox/drawable/model.cpp
@@ -56,7 +56,7 @@ Model::Model(Renderer* renderer, std::string_view model, std::string_view textur
 void Model::draw(Renderer* renderer, const mvp_t& mvp)
 {
     bind(renderer, mvp);
-    renderer->command()->bind(m_pipeline.get(), "u_Texture", m_texture.get());
+    renderer->command()->bind(m_pipeline.get(), "u_Texture", *m_texture);
     renderer->command()->draw(m_mesh);
 }
 

--- a/examples/sandbox/gui_layer/gui_layer_window.cpp
+++ b/examples/sandbox/gui_layer/gui_layer_window.cpp
@@ -86,7 +86,7 @@ GuiLayerWindow::GuiLayerWindow(std::string name)
     , m_camera_controller{makeScoped<Scene::VPCameraController>(m_camera)}
 {
     Framebuffer::config_t model_fbo_config{};
-    model_fbo_config.clear_color = {0.3f, 0.3f, 0.3f, 1.0f};
+    model_fbo_config.attachments[0].clear_color = {0.3f, 0.3f, 0.3f, 1.0f};
     model_fbo_config.size = {720.0f, 480.0f};
     model_fbo_config.msaa_samples = GE::Graphics::limits().max_msaa;
 

--- a/include/genesis/graphics/blending.h
+++ b/include/genesis/graphics/blending.h
@@ -1,7 +1,7 @@
 /*
  * BSD 3-Clause License
  *
- * Copyright (c) 2021-2022, Dmitry Shilnenkov
+ * Copyright (c) 2024, Dmitry Shilnenkov
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,24 +32,45 @@
 
 #pragma once
 
-#include <genesis/graphics/blending.h>
-#include <genesis/graphics/framebuffer.h>
-#include <genesis/graphics/gpu_command_queue.h>
-#include <genesis/graphics/graphics.h>
-#include <genesis/graphics/graphics_context.h>
-#include <genesis/graphics/graphics_factory.h>
-#include <genesis/graphics/index_buffer.h>
-#include <genesis/graphics/mesh.h>
-#include <genesis/graphics/pipeline.h>
-#include <genesis/graphics/render_command.h>
-#include <genesis/graphics/renderer.h>
-#include <genesis/graphics/shader.h>
-#include <genesis/graphics/shader_input_layout.h>
-#include <genesis/graphics/shader_precompiler.h>
-#include <genesis/graphics/shader_reflection.h>
-#include <genesis/graphics/shader_resource_descriptors.h>
-#include <genesis/graphics/texture.h>
-#include <genesis/graphics/texture_loader.h>
-#include <genesis/graphics/uniform_buffer.h>
-#include <genesis/graphics/vertex.h>
-#include <genesis/graphics/vertex_buffer.h>
+#include <genesis/core/export.h>
+
+#include <cstdint>
+
+enum class BlendFactor : uint8_t
+{
+    ZERO,
+    ONE,
+    SRC_COLOR,
+    ONE_MINUS_SRC_COLOR,
+    DST_COLOR,
+    ONE_MINUS_DST_COLOR,
+    SRC_ALPHA,
+    ONE_MINUS_SRC_ALPHA,
+    DST_ALPHA,
+    ONE_MINUS_DST_ALPHA,
+    CONSTANT_COLOR,
+    ONE_MINUS_CONSTANT_COLOR,
+    CONSTANT_ALPHA,
+    ONE_MINUS_CONSTANT_ALPHA
+};
+
+enum class BlendOp : uint8_t
+{
+    ADD,
+    SUBTRACT,
+    REVERSE_SUBTRACT,
+    MIN,
+    MAX
+};
+
+struct GE_API blending_t {
+    bool enabled{true};
+
+    BlendFactor src_color_factor{BlendFactor::SRC_ALPHA};
+    BlendFactor dst_color_factor{BlendFactor::ONE_MINUS_SRC_ALPHA};
+    BlendOp color_op{BlendOp::ADD};
+
+    BlendFactor src_alpha_factor{BlendFactor::SRC_ALPHA};
+    BlendFactor dst_alpha_factor{BlendFactor::ONE_MINUS_SRC_ALPHA};
+    BlendOp alpha_op{BlendOp::ADD};
+};

--- a/include/genesis/graphics/framebuffer.h
+++ b/include/genesis/graphics/framebuffer.h
@@ -56,6 +56,8 @@ struct fb_attachment_t {
     Type type{Type::UNKNOWN};
     TextureType texture_type{TextureType::UNKNOWN};
     TextureFormat texture_format{TextureFormat::UNKNOWN};
+    Vec4 clear_color{1.0f, 1.0f, 1.0f, 1.0f};
+    float clear_depth{1.0f};
 };
 
 class GE_API Framebuffer: public NonCopyable
@@ -65,8 +67,6 @@ public:
         Vec2 size{1920.0f, 1080.0f};
         uint32_t layers{1};
         uint32_t msaa_samples{1};
-        Vec4 clear_color{1.0f, 1.0f, 1.0f, 1.0f};
-        float clear_depth{1.0f};
         std::vector<fb_attachment_t> attachments = {
             {fb_attachment_t::Type::COLOR, TextureType::TEXTURE_2D, TextureFormat::SRGBA8},
             {fb_attachment_t::Type::DEPTH, TextureType::TEXTURE_2D, TextureFormat::D32F},
@@ -78,10 +78,8 @@ public:
     virtual Renderer* renderer() = 0;
     virtual const Vec2& size() const = 0;
     virtual uint32_t MSAASamples() const = 0;
-    virtual const Vec4& clearColor() const = 0;
-    virtual float clearDepth() const = 0;
 
-    virtual const Texture& colorTexture(size_t i = 0) const = 0;
+    virtual const Texture& colorTexture(uint32_t i = 0) const = 0;
     virtual const Texture& depthTexture() const = 0;
     virtual uint32_t colorAttachmentCount() const = 0;
     virtual bool hasDepthAttachment() const = 0;

--- a/include/genesis/graphics/gpu_command_queue.h
+++ b/include/genesis/graphics/gpu_command_queue.h
@@ -37,7 +37,6 @@
 
 #include <deque>
 #include <functional>
-#include <unordered_map>
 
 namespace GE {
 
@@ -49,16 +48,14 @@ public:
     using DelayedCommand = std::function<void(GPUCommandBuffer)>;
     using DelayedCommandQueue = std::deque<DelayedCommand>;
     using PipelineHandle = Pipeline::NativeHandle;
-    using QueueMap = std::unordered_map<PipelineHandle, DelayedCommandQueue>;
 
-    void setCurrentPipeline(Pipeline* pipeline);
     void enqueue(DelayedCommand cmd);
     void execCommands(GPUCommandBuffer cmd_buffer) const;
     void clear();
 
 private:
     PipelineHandle m_current_pipeline{};
-    QueueMap m_cmd_queue;
+    std::deque<DelayedCommand> m_cmd_queue;
 };
 
 } // namespace GE

--- a/include/genesis/graphics/pipeline.h
+++ b/include/genesis/graphics/pipeline.h
@@ -55,8 +55,9 @@ public:
     using NativeHandle = void*;
 
     virtual void bind(GPUCommandQueue* queue) = 0;
-    virtual void bind(GPUCommandQueue* queue, const std::string& name, UniformBuffer* ubo) = 0;
-    virtual void bind(GPUCommandQueue* queue, const std::string& name, Texture* texture) = 0;
+    virtual void bind(GPUCommandQueue* queue, const std::string& name,
+                      const UniformBuffer& ubo) = 0;
+    virtual void bind(GPUCommandQueue* queue, const std::string& name, const Texture& texture) = 0;
 
     virtual void pushConstant(GPUCommandQueue* queue, const std::string& name, bool value) = 0;
     virtual void pushConstant(GPUCommandQueue* queue, const std::string& name, int32_t value) = 0;

--- a/include/genesis/graphics/pipeline.h
+++ b/include/genesis/graphics/pipeline.h
@@ -46,6 +46,7 @@ class UniformBuffer;
 struct pipeline_config_t {
     Shared<Shader> vertex_shader{Shader::create(Shader::Type::VERTEX)};
     Shared<Shader> fragment_shader{Shader::create(Shader::Type::FRAGMENT)};
+    bool enable_blending{true};
 };
 
 class Pipeline: public Interface

--- a/include/genesis/graphics/pipeline.h
+++ b/include/genesis/graphics/pipeline.h
@@ -38,6 +38,9 @@
 #include <genesis/graphics/shader.h>
 #include <genesis/math/types.h>
 
+#include <variant>
+#include <vector>
+
 namespace GE {
 
 class GPUCommandQueue;
@@ -45,9 +48,11 @@ class Texture;
 class UniformBuffer;
 
 struct pipeline_config_t {
+    using BlendingCondig = std::variant<blending_t, std::vector<blending_t>>;
+
     Shared<Shader> vertex_shader{Shader::create(Shader::Type::VERTEX)};
     Shared<Shader> fragment_shader{Shader::create(Shader::Type::FRAGMENT)};
-    blending_t blending{};
+    BlendingCondig blending{blending_t{}};
 };
 
 class Pipeline: public Interface

--- a/include/genesis/graphics/pipeline.h
+++ b/include/genesis/graphics/pipeline.h
@@ -34,6 +34,7 @@
 
 #include <genesis/core/interface.h>
 #include <genesis/core/memory.h>
+#include <genesis/graphics/blending.h>
 #include <genesis/graphics/shader.h>
 #include <genesis/math/types.h>
 
@@ -46,7 +47,7 @@ class UniformBuffer;
 struct pipeline_config_t {
     Shared<Shader> vertex_shader{Shader::create(Shader::Type::VERTEX)};
     Shared<Shader> fragment_shader{Shader::create(Shader::Type::FRAGMENT)};
-    bool enable_blending{true};
+    blending_t blending{};
 };
 
 class Pipeline: public Interface

--- a/include/genesis/graphics/pipeline.h
+++ b/include/genesis/graphics/pipeline.h
@@ -65,6 +65,8 @@ public:
     virtual void pushConstant(GPUCommandQueue* queue, const std::string& name, float value) = 0;
     virtual void pushConstant(GPUCommandQueue* queue, const std::string& name, double value) = 0;
     virtual void pushConstant(GPUCommandQueue* queue, const std::string& name,
+                              const Vec2& value) = 0;
+    virtual void pushConstant(GPUCommandQueue* queue, const std::string& name,
                               const Vec3& value) = 0;
     virtual void pushConstant(GPUCommandQueue* queue, const std::string& name,
                               const Mat4& value) = 0;

--- a/include/genesis/graphics/pipeline.h
+++ b/include/genesis/graphics/pipeline.h
@@ -53,6 +53,8 @@ struct pipeline_config_t {
     Shared<Shader> vertex_shader{Shader::create(Shader::Type::VERTEX)};
     Shared<Shader> fragment_shader{Shader::create(Shader::Type::FRAGMENT)};
     BlendingCondig blending{blending_t{}};
+    bool depth_test_enable{true};
+    bool depth_write_enable{true};
 };
 
 class Pipeline: public Interface

--- a/include/genesis/graphics/render_command.h
+++ b/include/genesis/graphics/render_command.h
@@ -56,8 +56,8 @@ public:
     void bind(Pipeline* pipeline);
     void bind(VertexBuffer* buffer);
     void bind(IndexBuffer* buffer);
-    void bind(Pipeline* pipeline, const std::string& resource_name, UniformBuffer* buffer);
-    void bind(Pipeline* pipeline, const std::string& resource_name, Texture* texture);
+    void bind(Pipeline* pipeline, const std::string& resource_name, const UniformBuffer& buffer);
+    void bind(Pipeline* pipeline, const std::string& resource_name, const Texture& texture);
     template<typename T>
     void pushConstant(Pipeline* pipeline, const std::string& name, const T& value);
 

--- a/include/genesis/graphics/render_command.h
+++ b/include/genesis/graphics/render_command.h
@@ -36,7 +36,6 @@
 #include <genesis/core/memory.h>
 #include <genesis/graphics/gpu_command_queue.h>
 #include <genesis/graphics/pipeline.h>
-#include <genesis/math/types.h>
 
 namespace GE {
 
@@ -46,6 +45,7 @@ class Context;
 
 class IndexBuffer;
 class Mesh;
+class Renderer;
 class Texture;
 class UniformBuffer;
 class VertexBuffer;
@@ -53,6 +53,8 @@ class VertexBuffer;
 class GE_API RenderCommand
 {
 public:
+    explicit RenderCommand(Renderer* renderer);
+
     void bind(Pipeline* pipeline);
     void bind(VertexBuffer* buffer);
     void bind(IndexBuffer* buffer);
@@ -65,10 +67,13 @@ public:
     void draw(VertexBuffer* buffer, uint32_t vertex_count);
     void draw(VertexBuffer* vbo, IndexBuffer* ibo);
     void draw(GUI::Context* gui_layer);
+    void draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_vertex,
+              uint32_t first_instance);
 
     void submit(GPUCommandBuffer cmd);
 
 private:
+    Renderer* m_renderer{nullptr};
     GPUCommandQueue m_cmd_queue;
 };
 

--- a/include/genesis/graphics/renderer.h
+++ b/include/genesis/graphics/renderer.h
@@ -39,6 +39,7 @@
 namespace GE {
 
 class Event;
+class GPUCommandQueue;
 class Pipeline;
 class RenderCommand;
 struct pipeline_config_t;
@@ -53,6 +54,9 @@ public:
         CLEAR_DEPTH,
         CLEAR_ALL
     };
+
+    virtual void draw(GPUCommandQueue* queue, uint32_t vertex_count, uint32_t instance_count,
+                      uint32_t first_vertex, uint32_t first_instance) = 0;
 
     virtual bool beginFrame(ClearMode clear_mode = CLEAR_ALL) = 0;
     virtual void endFrame() = 0;

--- a/include/genesis/graphics/renderer.h
+++ b/include/genesis/graphics/renderer.h
@@ -34,6 +34,7 @@
 
 #include <genesis/core/interface.h>
 #include <genesis/graphics/render_command.h>
+#include <genesis/math/types.h>
 
 namespace GE {
 
@@ -59,6 +60,7 @@ public:
 
     virtual void onEvent(Event* event) = 0;
 
+    virtual Vec2 size() const = 0;
     virtual RenderCommand* command() = 0;
 
     virtual Scoped<Pipeline> createPipeline(const pipeline_config_t& config) = 0;

--- a/include/genesis/graphics/texture.h
+++ b/include/genesis/graphics/texture.h
@@ -95,6 +95,7 @@ struct texture_config_t {
     TextureWrap wrap_w{TextureWrap::REPEAT};
     uint32_t mip_levels{MIP_LEVELS_AUTO};
     bool image_storage{false};
+    bool is_opaque{true};
 
     static constexpr uint32_t MIP_LEVELS_AUTO{0};
 };
@@ -107,6 +108,7 @@ public:
     virtual bool setData(const void* data, uint32_t size) = 0;
     virtual const Vec2& size() const = 0;
     virtual TextureFormat format() const = 0;
+    virtual bool isOpaque() const = 0;
     virtual NativeID nativeID() const = 0;
 
     static Scoped<Texture> create(const texture_config_t& config);
@@ -114,7 +116,7 @@ public:
     static uint32_t calculateMipLevels(uint32_t width, uint32_t height);
 };
 
-inline constexpr bool isDepthFormat(TextureFormat format)
+constexpr bool isDepthFormat(TextureFormat format)
 {
     switch (format) {
         case TextureFormat::D32F:
@@ -124,12 +126,12 @@ inline constexpr bool isDepthFormat(TextureFormat format)
     }
 }
 
-inline constexpr bool isColorFormat(TextureFormat format)
+constexpr bool isColorFormat(TextureFormat format)
 {
     return !isDepthFormat(format);
 }
 
-inline constexpr uint32_t toTextureBPP(TextureFormat format)
+constexpr uint32_t toTextureBPP(TextureFormat format)
 {
     switch (format) {
         case TextureFormat::R8: return 1;

--- a/include/genesis/graphics/texture.h
+++ b/include/genesis/graphics/texture.h
@@ -54,6 +54,8 @@ enum class TextureFormat : uint8_t
     RGBA8,
     SRGB8,
     SRGBA8,
+    R16F,
+    RGBA16F,
     R32F,
     RGBA32F,
     D32F,

--- a/include/genesis/gui/widgets/text.h
+++ b/include/genesis/gui/widgets/text.h
@@ -42,4 +42,9 @@ public:
     static void call(std::string_view fmt, ...);
 };
 
+constexpr std::string_view toString(bool value)
+{
+    return value ? "true" : "false";
+}
+
 } // namespace GE::GUI

--- a/include/genesis/scene/renderer/irenderer.h
+++ b/include/genesis/scene/renderer/irenderer.h
@@ -34,6 +34,8 @@
 
 #include <genesis/core/interface.h>
 
+#include <string_view>
+
 namespace GE {
 class Renderer;
 } // namespace GE
@@ -45,7 +47,8 @@ class Scene;
 class GE_API IRenderer: public Interface
 {
 public:
-    virtual void render(GE::Renderer* renderer, const Scene& scene) = 0;
+    virtual void render(const Scene& scene) = 0;
+    virtual std::string_view type() const = 0;
 };
 
 } // namespace GE::Scene

--- a/include/genesis/scene/renderer/irenderer.h
+++ b/include/genesis/scene/renderer/irenderer.h
@@ -32,5 +32,20 @@
 
 #pragma once
 
-#include <genesis/scene/renderer/irenderer.h>
-#include <genesis/scene/renderer/plain_renderer.h>
+#include <genesis/core/interface.h>
+
+namespace GE {
+class Renderer;
+} // namespace GE
+
+namespace GE::Scene {
+
+class Scene;
+
+class GE_API IRenderer: public Interface
+{
+public:
+    virtual void render(GE::Renderer* renderer, const Scene& scene) = 0;
+};
+
+} // namespace GE::Scene

--- a/include/genesis/scene/renderer/plain_renderer.h
+++ b/include/genesis/scene/renderer/plain_renderer.h
@@ -1,7 +1,7 @@
 /*
  * BSD 3-Clause License
  *
- * Copyright (c) 2024, Dmitry Shilnenkov
+ * Copyright (c) 2023, Dmitry Shilnenkov
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,5 +32,36 @@
 
 #pragma once
 
+#include <genesis/core/export.h>
+#include <genesis/core/memory.h>
 #include <genesis/scene/renderer/irenderer.h>
-#include <genesis/scene/renderer/plain_renderer.h>
+
+namespace GE {
+class UniformBuffer;
+} // namespace GE
+
+namespace GE::Scene {
+
+class Entity;
+class ViewProjectionCamera;
+
+class GE_API PlainRenderer: public GE::Scene::IRenderer
+{
+public:
+    explicit PlainRenderer(const ViewProjectionCamera* camera);
+    ~PlainRenderer();
+
+    void render(GE::Renderer* renderer, const Scene& scene) override;
+
+private:
+    void renderSprite(GE::Renderer* renderer, const Entity& entity);
+
+    void updateViewProjectionUBO();
+
+    const GE::Scene::ViewProjectionCamera* m_camera{nullptr};
+
+    Scoped<UniformBuffer> m_vp_ubo;
+    Scoped<UniformBuffer> m_translation_ubo;
+};
+
+} // namespace GE::Scene

--- a/include/genesis/scene/renderer/plain_renderer.h
+++ b/include/genesis/scene/renderer/plain_renderer.h
@@ -32,36 +32,19 @@
 
 #pragma once
 
-#include <genesis/core/export.h>
-#include <genesis/core/memory.h>
-#include <genesis/scene/renderer/irenderer.h>
-
-namespace GE {
-class UniformBuffer;
-} // namespace GE
+#include <genesis/scene/renderer/renderer_base.h>
 
 namespace GE::Scene {
 
-class Entity;
-class ViewProjectionCamera;
-
-class GE_API PlainRenderer: public GE::Scene::IRenderer
+class GE_API PlainRenderer: public RendererBase
 {
 public:
-    explicit PlainRenderer(const ViewProjectionCamera* camera);
-    ~PlainRenderer();
+    using RendererBase::RendererBase;
 
-    void render(GE::Renderer* renderer, const Scene& scene) override;
+    void render(const Scene& scene) override;
+    std::string_view type() const override { return TYPE; }
 
-private:
-    void renderSprite(GE::Renderer* renderer, const Entity& entity);
-
-    void updateViewProjectionUBO();
-
-    const GE::Scene::ViewProjectionCamera* m_camera{nullptr};
-
-    Scoped<UniformBuffer> m_vp_ubo;
-    Scoped<UniformBuffer> m_translation_ubo;
+    static constexpr std::string_view TYPE = "Plain Scene Renderer";
 };
 
 } // namespace GE::Scene

--- a/include/genesis/scene/renderer/renderer_base.h
+++ b/include/genesis/scene/renderer/renderer_base.h
@@ -32,6 +32,36 @@
 
 #pragma once
 
+#include "genesis/graphics/pipeline.h"
+
 #include <genesis/scene/renderer/irenderer.h>
-#include <genesis/scene/renderer/plain_renderer.h>
-#include <genesis/scene/renderer/renderer_base.h>
+
+#include <string>
+
+namespace GE {
+class Mesh;
+class Pipeline;
+class Texture;
+} // namespace GE
+
+namespace GE::Scene {
+
+class Entity;
+class ViewProjectionCamera;
+
+class RendererBase: public IRenderer
+{
+public:
+    RendererBase(GE::Renderer* renderer, const ViewProjectionCamera* camera);
+
+protected:
+    void renderEntity(GE::Renderer* renderer, Pipeline* pipeline, const Entity& entity);
+
+    bool isValid(std::string_view entity_name, Pipeline* material, Texture* texture,
+                 Mesh* mesh) const;
+
+    GE::Renderer* m_renderer{nullptr};
+    const ViewProjectionCamera* m_camera{nullptr};
+};
+
+} // namespace GE::Scene

--- a/include/genesis/scene/renderer/wb_oit_renderer.h
+++ b/include/genesis/scene/renderer/wb_oit_renderer.h
@@ -32,7 +32,46 @@
 
 #pragma once
 
-#include <genesis/scene/renderer/irenderer.h>
-#include <genesis/scene/renderer/plain_renderer.h>
+#include <genesis/core/memory.h>
+#include <genesis/math/types.h>
 #include <genesis/scene/renderer/renderer_base.h>
-#include <genesis/scene/renderer/wb_oit_renderer.h>
+
+namespace GE {
+class Framebuffer;
+} // namespace GE
+
+namespace GE::Assets {
+class Registry;
+} // namespace GE::Assets
+
+namespace GE::Scene {
+
+class Entity;
+
+class WeightedBlendedOITRenderer: public RendererBase
+{
+public:
+    explicit WeightedBlendedOITRenderer(GE::Renderer* renderer, const ViewProjectionCamera* camera);
+
+    void render(const Scene& scene) override;
+    std::string_view type() const override { return TYPE; }
+
+    static constexpr std::string_view TYPE = "Weighted-Blended OIT Scene Renderer";
+
+private:
+    void recreateWbOitFramebuffer(const Vec2& size);
+    void createOpaqueColorPipeline(GE::Renderer* renderer);
+    void createAccumulationPipeline(GE::Renderer* renderer);
+    void createComposingPipeline(GE::Renderer* renderer);
+
+    void renderOpaqueEntities(GE::Renderer* renderer, const Scene& scene);
+    void renderTransparentEntities(GE::Renderer* renderer, const Scene& scene);
+    void composeScene(GE::Renderer* renderer);
+
+    Scoped<Framebuffer> m_wb_oit_fbo;
+    Shared<Pipeline> m_color_pipeline;
+    Shared<Pipeline> m_accumulation_pipeline;
+    Shared<Pipeline> m_composing_pipeline;
+};
+
+} // namespace GE::Scene

--- a/src/genesis/graphics/CMakeLists.txt
+++ b/src/genesis/graphics/CMakeLists.txt
@@ -18,6 +18,7 @@ list(APPEND GRAPHICS_SOURCES
     )
 
 list(APPEND GRAPHICS_HEADERS
+    ${INCLUDE_DIR}/blending.h
     ${INCLUDE_DIR}/framebuffer.h
     ${INCLUDE_DIR}/gpu_command_queue.h
     ${INCLUDE_DIR}/graphics.h

--- a/src/genesis/graphics/gpu_command_queue.cpp
+++ b/src/genesis/graphics/gpu_command_queue.cpp
@@ -34,26 +34,15 @@
 
 namespace GE {
 
-void GPUCommandQueue::setCurrentPipeline(Pipeline* pipeline)
-{
-    m_current_pipeline = pipeline->nativeHandle();
-
-    if (m_cmd_queue.find(m_current_pipeline) == m_cmd_queue.end()) {
-        pipeline->bind(this);
-    }
-}
-
 void GPUCommandQueue::enqueue(GPUCommandQueue::DelayedCommand cmd)
 {
-    m_cmd_queue[m_current_pipeline].push_back(std::move(cmd));
+    m_cmd_queue.push_back(std::move(cmd));
 }
 
 void GPUCommandQueue::execCommands(GPUCommandBuffer cmd_buffer) const
 {
-    for (const auto& [_, queue] : m_cmd_queue) {
-        for (const auto& cmd : queue) {
-            cmd(cmd_buffer);
-        }
+    for (const auto& cmd : m_cmd_queue) {
+        cmd(cmd_buffer);
     }
 }
 

--- a/src/genesis/graphics/render_command.cpp
+++ b/src/genesis/graphics/render_command.cpp
@@ -47,7 +47,7 @@ RenderCommand::RenderCommand(Renderer *renderer)
 
 void RenderCommand::bind(Pipeline *pipeline)
 {
-    m_cmd_queue.setCurrentPipeline(pipeline);
+    pipeline->bind(&m_cmd_queue);
 }
 
 void RenderCommand::bind(VertexBuffer *buffer)

--- a/src/genesis/graphics/render_command.cpp
+++ b/src/genesis/graphics/render_command.cpp
@@ -34,11 +34,16 @@
 #include "index_buffer.h"
 #include "mesh.h"
 #include "pipeline.h"
+#include "renderer.h"
 #include "vertex_buffer.h"
 
 #include "genesis/gui/context.h"
 
 namespace GE {
+
+RenderCommand::RenderCommand(Renderer *renderer)
+    : m_renderer{renderer}
+{}
 
 void RenderCommand::bind(Pipeline *pipeline)
 {
@@ -88,6 +93,12 @@ void RenderCommand::draw(VertexBuffer *vbo, IndexBuffer *ibo)
 void RenderCommand::draw(GUI::Context *gui_layer)
 {
     gui_layer->draw(&m_cmd_queue);
+}
+
+void RenderCommand::draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_vertex,
+                         uint32_t first_instance)
+{
+    m_renderer->draw(&m_cmd_queue, vertex_count, instance_count, first_vertex, first_instance);
 }
 
 void RenderCommand::submit(GPUCommandBuffer cmd)

--- a/src/genesis/graphics/render_command.cpp
+++ b/src/genesis/graphics/render_command.cpp
@@ -56,12 +56,13 @@ void RenderCommand::bind(IndexBuffer *buffer)
 }
 
 void RenderCommand::bind(Pipeline *pipeline, const std::string &resource_name,
-                         UniformBuffer *buffer)
+                         const UniformBuffer &buffer)
 {
     pipeline->bind(&m_cmd_queue, resource_name, buffer);
 }
 
-void RenderCommand::bind(Pipeline *pipeline, const std::string &resource_name, Texture *texture)
+void RenderCommand::bind(Pipeline *pipeline, const std::string &resource_name,
+                         const Texture &texture)
 {
     pipeline->bind(&m_cmd_queue, resource_name, texture);
 }

--- a/src/genesis/graphics/shader_precompiler.cpp
+++ b/src/genesis/graphics/shader_precompiler.cpp
@@ -75,7 +75,7 @@ ShaderCache ShaderPrecompiler::compileFromFile(Shader::Type shader_type,
 ShaderCache ShaderPrecompiler::compileFromSource(Shader::Type shader_type,
                                                  const std::string &source_code)
 {
-    return compileShader(shader_type, source_code, {});
+    return compileShader(shader_type, source_code, "<no-filename>");
 }
 
 ShaderCache ShaderPrecompiler::compileShader(Shader::Type type, const std::string &source_code,

--- a/src/genesis/graphics/vulkan/CMakeLists.txt
+++ b/src/genesis/graphics/vulkan/CMakeLists.txt
@@ -7,6 +7,7 @@ list(APPEND GRAPHICS_VULKAN_SOURCES
     renderers/framebuffer_renderer.cpp
     renderers/renderer_base.cpp
     renderers/window_renderer.cpp
+    blending.cpp
     descriptor_pool.cpp
     device.cpp
     framebuffer.cpp
@@ -36,6 +37,7 @@ list(APPEND GRAPHICS_VULKAN_HEADERS
     renderers/framebuffer_renderer.h
     renderers/renderer_base.h
     renderers/window_renderer.h
+    blending.h
     command_buffer.h
     descriptor_pool.h
     device.h

--- a/src/genesis/graphics/vulkan/blending.cpp
+++ b/src/genesis/graphics/vulkan/blending.cpp
@@ -1,0 +1,76 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Dmitry Shilnenkov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "blending.h"
+
+#include "genesis/core/asserts.h"
+
+namespace GE::Vulkan {
+
+VkBlendFactor toVkBlendFactor(BlendFactor factor)
+{
+    switch (factor) {
+        case BlendFactor::ZERO: return VK_BLEND_FACTOR_ZERO;
+        case BlendFactor::ONE: return VK_BLEND_FACTOR_ONE;
+        case BlendFactor::SRC_COLOR: return VK_BLEND_FACTOR_SRC_COLOR;
+        case BlendFactor::ONE_MINUS_SRC_COLOR: return VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR;
+        case BlendFactor::DST_COLOR: return VK_BLEND_FACTOR_DST_COLOR;
+        case BlendFactor::ONE_MINUS_DST_COLOR: return VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR;
+        case BlendFactor::SRC_ALPHA: return VK_BLEND_FACTOR_SRC_ALPHA;
+        case BlendFactor::ONE_MINUS_SRC_ALPHA: return VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+        case BlendFactor::DST_ALPHA: return VK_BLEND_FACTOR_DST_ALPHA;
+        case BlendFactor::ONE_MINUS_DST_ALPHA: return VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA;
+        case BlendFactor::CONSTANT_COLOR: return VK_BLEND_FACTOR_CONSTANT_COLOR;
+        case BlendFactor::ONE_MINUS_CONSTANT_COLOR: return VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR;
+        case BlendFactor::CONSTANT_ALPHA: return VK_BLEND_FACTOR_CONSTANT_ALPHA;
+        case BlendFactor::ONE_MINUS_CONSTANT_ALPHA: return VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
+        default: GE_CORE_ASSERT("Unsupported blendign factor: {}", factor);
+    }
+
+    return VK_BLEND_FACTOR_ZERO;
+}
+
+VkBlendOp toVkBlendOp(BlendOp op)
+{
+    switch (op) {
+        case BlendOp::ADD: return VK_BLEND_OP_ADD;
+        case BlendOp::SUBTRACT: return VK_BLEND_OP_SUBTRACT;
+        case BlendOp::REVERSE_SUBTRACT: return VK_BLEND_OP_REVERSE_SUBTRACT;
+        case BlendOp::MIN: return VK_BLEND_OP_MIN;
+        case BlendOp::MAX: return VK_BLEND_OP_MAX;
+        default: GE_CORE_ASSERT("Unsupported blendign op: {}", op);
+    }
+
+    return VK_BLEND_OP_ADD;
+}
+
+} // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/blending.h
+++ b/src/genesis/graphics/vulkan/blending.h
@@ -1,7 +1,7 @@
 /*
  * BSD 3-Clause License
  *
- * Copyright (c) 2021-2022, Dmitry Shilnenkov
+ * Copyright (c) 2024, Dmitry Shilnenkov
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,23 +33,12 @@
 #pragma once
 
 #include <genesis/graphics/blending.h>
-#include <genesis/graphics/framebuffer.h>
-#include <genesis/graphics/gpu_command_queue.h>
-#include <genesis/graphics/graphics.h>
-#include <genesis/graphics/graphics_context.h>
-#include <genesis/graphics/graphics_factory.h>
-#include <genesis/graphics/index_buffer.h>
-#include <genesis/graphics/mesh.h>
-#include <genesis/graphics/pipeline.h>
-#include <genesis/graphics/render_command.h>
-#include <genesis/graphics/renderer.h>
-#include <genesis/graphics/shader.h>
-#include <genesis/graphics/shader_input_layout.h>
-#include <genesis/graphics/shader_precompiler.h>
-#include <genesis/graphics/shader_reflection.h>
-#include <genesis/graphics/shader_resource_descriptors.h>
-#include <genesis/graphics/texture.h>
-#include <genesis/graphics/texture_loader.h>
-#include <genesis/graphics/uniform_buffer.h>
-#include <genesis/graphics/vertex.h>
-#include <genesis/graphics/vertex_buffer.h>
+
+#include <vulkan/vulkan.h>
+
+namespace GE::Vulkan {
+
+GE_API VkBlendFactor toVkBlendFactor(BlendFactor factor);
+GE_API VkBlendOp toVkBlendOp(BlendOp op);
+
+} // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/buffers/index_buffer.cpp
+++ b/src/genesis/graphics/vulkan/buffers/index_buffer.cpp
@@ -51,7 +51,7 @@ IndexBuffer::IndexBuffer(Shared<Device> device, const uint32_t* indices, uint32_
 void IndexBuffer::bind(GPUCommandQueue* cmd_queue) const
 {
     cmd_queue->enqueue([this](void* cmd) {
-        vkCmdBindIndexBuffer(cmdBuffer(cmd), m_buffer, 0, VK_INDEX_TYPE_UINT32);
+        vkCmdBindIndexBuffer(toVkCommandBuffer(cmd), m_buffer, 0, VK_INDEX_TYPE_UINT32);
     });
 }
 

--- a/src/genesis/graphics/vulkan/buffers/vertex_buffer.cpp
+++ b/src/genesis/graphics/vulkan/buffers/vertex_buffer.cpp
@@ -56,19 +56,20 @@ void VertexBuffer::bind(GPUCommandQueue *queue) const
 {
     queue->enqueue([this](void *cmd) {
         constexpr VkDeviceSize offsets{0};
-        vkCmdBindVertexBuffers(cmdBuffer(cmd), 0, 1, &m_buffer, &offsets);
+        vkCmdBindVertexBuffers(toVkCommandBuffer(cmd), 0, 1, &m_buffer, &offsets);
     });
 }
 
 void VertexBuffer::draw(GPUCommandQueue *queue, uint32_t vertex_count) const
 {
-    queue->enqueue([vertex_count](void *cmd) { vkCmdDraw(cmdBuffer(cmd), vertex_count, 1, 0, 0); });
+    queue->enqueue(
+        [vertex_count](void *cmd) { vkCmdDraw(toVkCommandBuffer(cmd), vertex_count, 1, 0, 0); });
 }
 
 void VertexBuffer::draw(GPUCommandQueue *queue, GE::IndexBuffer *ibo) const
 {
     queue->enqueue(
-        [ibo](void *cmd) { vkCmdDrawIndexed(cmdBuffer(cmd), ibo->count(), 1, 0, 0, 0); });
+        [ibo](void *cmd) { vkCmdDrawIndexed(toVkCommandBuffer(cmd), ibo->count(), 1, 0, 0, 0); });
 }
 
 void VertexBuffer::setVertices(const void *vertices, uint32_t size)

--- a/src/genesis/graphics/vulkan/command_buffer.h
+++ b/src/genesis/graphics/vulkan/command_buffer.h
@@ -36,9 +36,9 @@
 
 namespace GE::Vulkan {
 
-inline VkCommandBuffer cmdBuffer(void* cmd)
+constexpr VkCommandBuffer toVkCommandBuffer(void* cmd)
 {
-    return reinterpret_cast<VkCommandBuffer>(cmd);
+    return static_cast<VkCommandBuffer>(cmd);
 }
 
 } // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/descriptor_pool.h
+++ b/src/genesis/graphics/vulkan/descriptor_pool.h
@@ -37,6 +37,8 @@
 #include <vulkan/vulkan.h>
 
 #include <list>
+#include <unordered_map>
+#include <vector>
 
 namespace GE::Vulkan {
 
@@ -48,14 +50,14 @@ public:
     explicit DescriptorPool(Shared<Device> device, uint32_t count = MAX_COUNT_DEFAULT);
     ~DescriptorPool();
 
-    VkDescriptorSet allocateDescriptorSet(VkDescriptorSetLayout layout);
+    VkDescriptorSet allocateDescriptorSet(VkDescriptorSetLayout layout, bool use_cache);
     void reset();
 
     static constexpr uint32_t MAX_COUNT_DEFAULT{1000};
 
 private:
     VkResult allocateDescriptorSet(VkDescriptorPool pool, VkDescriptorSetLayout layout,
-                                   VkDescriptorSet *set);
+                                   VkDescriptorSet* set);
     VkDescriptorPool getPool();
     VkDescriptorPool createPool();
 
@@ -65,6 +67,7 @@ private:
     std::list<VkDescriptorPool> m_pools;
     std::vector<VkDescriptorPoolSize> m_sizes;
     uint32_t m_max_count{};
+    std::unordered_map<VkDescriptorSetLayout, VkDescriptorSet> m_cache;
 };
 
 } // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/framebuffer.cpp
+++ b/src/genesis/graphics/vulkan/framebuffer.cpp
@@ -156,7 +156,7 @@ Framebuffer::createDepthRenderingAttachment(const Scoped<Vulkan::Texture>& textu
     attachment.sType = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO;
     attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     attachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 
     if (m_config.msaa_samples > 1) {
         attachment.imageView = m_depth_msaa_image->view();
@@ -236,7 +236,7 @@ Framebuffer::colorRenderingAttachments(Renderer::ClearMode clear_mode)
     for (uint32_t i{0}; i < m_color_rendering_attachments.size(); i++) {
         auto& color_attachment = m_color_rendering_attachments[i];
         color_attachment.loadOp = should_clear ? VK_ATTACHMENT_LOAD_OP_CLEAR
-                                               : VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+                                               : VK_ATTACHMENT_LOAD_OP_LOAD;
     }
 
     return m_color_rendering_attachments;
@@ -247,7 +247,7 @@ Framebuffer::depthRenderingAttachment(Renderer::ClearMode clear_mode)
 {
     bool should_clear = clear_mode == Renderer::CLEAR_DEPTH || clear_mode == Renderer::CLEAR_ALL;
     m_depth_rendering_attachment.loadOp = should_clear ? VK_ATTACHMENT_LOAD_OP_CLEAR
-                                                       : VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+                                                       : VK_ATTACHMENT_LOAD_OP_LOAD;
     return m_depth_rendering_attachment;
 }
 

--- a/src/genesis/graphics/vulkan/framebuffer.h
+++ b/src/genesis/graphics/vulkan/framebuffer.h
@@ -54,10 +54,8 @@ public:
     Renderer* renderer() override;
     const Vec2& size() const override { return m_config.size; }
     uint32_t MSAASamples() const override { return m_config.msaa_samples; }
-    const Vec4& clearColor() const override { return m_config.clear_color; }
-    float clearDepth() const override { return m_config.clear_depth; }
 
-    const Vulkan::Texture& colorTexture(size_t i) const override;
+    const Vulkan::Texture& colorTexture(uint32_t i) const override;
     const Vulkan::Texture& depthTexture() const override;
     uint32_t colorAttachmentCount() const override;
     bool hasDepthAttachment() const override;
@@ -86,10 +84,12 @@ private:
     std::vector<Scoped<Vulkan::Texture>> m_color_textures;
     std::vector<Scoped<Image>> m_color_msaa_images;
     std::vector<VkRenderingAttachmentInfo> m_color_rendering_attachments;
+    std::vector<Vec4> m_clear_color;
 
     Scoped<Vulkan::Texture> m_depth_texture;
     Scoped<Image> m_depth_msaa_image;
     VkRenderingAttachmentInfo m_depth_rendering_attachment{};
+    float m_clear_depth{1.0f};
 };
 
 } // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/pipeline.cpp
+++ b/src/genesis/graphics/vulkan/pipeline.cpp
@@ -138,7 +138,7 @@ void Pipeline::bind(GPUCommandQueue* queue, const std::string& name, const GE::U
 
 void Pipeline::bind(GPUCommandQueue* queue, const std::string& name, const GE::Texture& texture)
 {
-    const auto* vk_texture = toVulan(texture);
+    const auto* vk_texture = toVulkan(texture);
 
     VkDescriptorImageInfo info{};
     info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
@@ -226,8 +226,8 @@ Vulkan::pipeline_config_t Pipeline::createDefaultConfig(GE::pipeline_config_t ba
     config.multisample_state.alphaToOneEnable = VK_FALSE;      // Optional
 
     config.depth_stencil_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-    config.depth_stencil_state.depthTestEnable = VK_TRUE;
-    config.depth_stencil_state.depthWriteEnable = VK_TRUE;
+    config.depth_stencil_state.depthTestEnable = toVkBool(config.depth_test_enable);
+    config.depth_stencil_state.depthWriteEnable = toVkBool(config.depth_write_enable);
     config.depth_stencil_state.depthCompareOp = VK_COMPARE_OP_LESS;
     config.depth_stencil_state.depthBoundsTestEnable = VK_FALSE;
     config.depth_stencil_state.stencilTestEnable = VK_FALSE;
@@ -402,7 +402,7 @@ template<>
 void Pipeline::pushConstantCmd<bool>(GPUCommandQueue* queue, const push_constant_t& push_constant,
                                      bool value)
 {
-    queue->enqueue([this, &push_constant, vk_value = value ? VK_TRUE : VK_FALSE](void* cmd_buffer) {
+    queue->enqueue([this, &push_constant, vk_value = toVkBool(value)](void* cmd_buffer) {
         vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,
                            push_constant.pipeline_stages, push_constant.offset, push_constant.size,
                            &vk_value);

--- a/src/genesis/graphics/vulkan/pipeline.cpp
+++ b/src/genesis/graphics/vulkan/pipeline.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "pipeline.h"
+#include "blending.h"
 #include "buffers/uniform_buffer.h"
 #include "command_buffer.h"
 #include "device.h"
@@ -266,13 +267,13 @@ void Pipeline::createPipeline(Vulkan::pipeline_config_t config)
     VkPipelineColorBlendAttachmentState color_blend_attachment{};
     color_blend_attachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
                                             VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-    color_blend_attachment.blendEnable = config.enable_blending ? VK_TRUE : VK_FALSE;
-    color_blend_attachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
-    color_blend_attachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-    color_blend_attachment.colorBlendOp = VK_BLEND_OP_ADD;
-    color_blend_attachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
-    color_blend_attachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-    color_blend_attachment.alphaBlendOp = VK_BLEND_OP_ADD;
+    color_blend_attachment.blendEnable = config.blending.enabled ? VK_TRUE : VK_FALSE;
+    color_blend_attachment.srcColorBlendFactor = toVkBlendFactor(config.blending.src_color_factor);
+    color_blend_attachment.dstColorBlendFactor = toVkBlendFactor(config.blending.dst_color_factor);
+    color_blend_attachment.colorBlendOp = toVkBlendOp(config.blending.color_op);
+    color_blend_attachment.srcAlphaBlendFactor = toVkBlendFactor(config.blending.src_alpha_factor);
+    color_blend_attachment.dstAlphaBlendFactor = toVkBlendFactor(config.blending.dst_alpha_factor);
+    color_blend_attachment.alphaBlendOp = toVkBlendOp(config.blending.alpha_op);
 
     std::vector<VkPipelineColorBlendAttachmentState> color_blend_attachments(
         config.color_formats.size());

--- a/src/genesis/graphics/vulkan/pipeline.cpp
+++ b/src/genesis/graphics/vulkan/pipeline.cpp
@@ -256,10 +256,12 @@ void Pipeline::createPipeline(Vulkan::pipeline_config_t config)
 
     VkPipelineVertexInputStateCreateInfo vertex_input_state{};
     vertex_input_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-    vertex_input_state.vertexBindingDescriptionCount = 1;
-    vertex_input_state.pVertexBindingDescriptions = &binding_description;
-    vertex_input_state.vertexAttributeDescriptionCount = attribute_descriptions.size();
-    vertex_input_state.pVertexAttributeDescriptions = attribute_descriptions.data();
+    if (!attribute_descriptions.empty()) {
+        vertex_input_state.vertexBindingDescriptionCount = 1;
+        vertex_input_state.pVertexBindingDescriptions = &binding_description;
+        vertex_input_state.vertexAttributeDescriptionCount = attribute_descriptions.size();
+        vertex_input_state.pVertexAttributeDescriptions = attribute_descriptions.data();
+    }
 
     config.rasterization_state.frontFace = config.front_face;
     config.multisample_state.rasterizationSamples = config.msaa_samples;
@@ -326,7 +328,7 @@ void Pipeline::bindResource(GPUCommandQueue* queue, const std::string& name,
     auto resource = m_resources->resource(name);
 
     if (!resource.has_value()) {
-        GE_ERR("Failed to bound '{}': there is no such resource", name);
+        GE_CORE_ERR("Failed to bind '{}': there is no such resource", name);
         return;
     }
 

--- a/src/genesis/graphics/vulkan/pipeline.cpp
+++ b/src/genesis/graphics/vulkan/pipeline.cpp
@@ -332,7 +332,11 @@ void Pipeline::bindResource(GPUCommandQueue* queue, const std::string& name,
         return;
     }
 
-    auto* descriptor_set = m_resources->descriptorSet(resource->set);
+    auto* descriptor_set = m_resources->descriptorSet(resource.value());
+    if (descriptor_set == VK_NULL_HANDLE) {
+        GE_CORE_ERR("Failed to allocate Descriptor Set for '{}'", name);
+        return;
+    }
 
     write_descriptor_set->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     write_descriptor_set->dstSet = descriptor_set;

--- a/src/genesis/graphics/vulkan/pipeline.cpp
+++ b/src/genesis/graphics/vulkan/pipeline.cpp
@@ -79,7 +79,8 @@ Pipeline::~Pipeline()
 void Pipeline::bind(GPUCommandQueue* queue)
 {
     queue->enqueue([this](void* cmd_buffer) {
-        vkCmdBindPipeline(cmdBuffer(cmd_buffer), VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
+        vkCmdBindPipeline(toVkCommandBuffer(cmd_buffer), VK_PIPELINE_BIND_POINT_GRAPHICS,
+                          m_pipeline);
     });
 }
 
@@ -339,8 +340,8 @@ void Pipeline::bindResource(GPUCommandQueue* queue, const std::string& name,
     vkUpdateDescriptorSets(m_device->device(), 1, write_descriptor_set, 0, nullptr);
 
     queue->enqueue([this, set = resource->set, descriptor_set](void* cmd) {
-        vkCmdBindDescriptorSets(cmdBuffer(cmd), VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline_layout,
-                                set, 1, &descriptor_set, 0, nullptr);
+        vkCmdBindDescriptorSets(toVkCommandBuffer(cmd), VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                m_pipeline_layout, set, 1, &descriptor_set, 0, nullptr);
     });
 }
 
@@ -358,8 +359,9 @@ void Pipeline::pushConstantCmd(GPUCommandQueue* queue, const push_constant_t& pu
                                T value)
 {
     queue->enqueue([this, &push_constant, value](void* cmd_buffer) {
-        vkCmdPushConstants(cmdBuffer(cmd_buffer), m_pipeline_layout, push_constant.pipeline_stages,
-                           push_constant.offset, push_constant.size, &value);
+        vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,
+                           push_constant.pipeline_stages, push_constant.offset, push_constant.size,
+                           &value);
     });
 }
 
@@ -368,8 +370,9 @@ void Pipeline::pushConstantCmd<bool>(GPUCommandQueue* queue, const push_constant
                                      bool value)
 {
     queue->enqueue([this, &push_constant, vk_value = value ? VK_TRUE : VK_FALSE](void* cmd_buffer) {
-        vkCmdPushConstants(cmdBuffer(cmd_buffer), m_pipeline_layout, push_constant.pipeline_stages,
-                           push_constant.offset, push_constant.size, &vk_value);
+        vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,
+                           push_constant.pipeline_stages, push_constant.offset, push_constant.size,
+                           &vk_value);
     });
 }
 
@@ -378,8 +381,9 @@ void Pipeline::pushConstantCmd<const Vec3&>(GPUCommandQueue* queue,
                                             const push_constant_t& push_constant, const Vec3& value)
 {
     queue->enqueue([this, &push_constant, &value](void* cmd_buffer) {
-        vkCmdPushConstants(cmdBuffer(cmd_buffer), m_pipeline_layout, push_constant.pipeline_stages,
-                           push_constant.offset, push_constant.size, value_ptr(value));
+        vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,
+                           push_constant.pipeline_stages, push_constant.offset, push_constant.size,
+                           value_ptr(value));
     });
 }
 
@@ -388,8 +392,9 @@ void Pipeline::pushConstantCmd<const Mat4&>(GPUCommandQueue* queue,
                                             const push_constant_t& push_constant, const Mat4& value)
 {
     queue->enqueue([this, &push_constant, &value](void* cmd_buffer) {
-        vkCmdPushConstants(cmdBuffer(cmd_buffer), m_pipeline_layout, push_constant.pipeline_stages,
-                           push_constant.offset, push_constant.size, value_ptr(value));
+        vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,
+                           push_constant.pipeline_stages, push_constant.offset, push_constant.size,
+                           value_ptr(value));
     });
 }
 

--- a/src/genesis/graphics/vulkan/pipeline.cpp
+++ b/src/genesis/graphics/vulkan/pipeline.cpp
@@ -135,6 +135,11 @@ void Pipeline::pushConstant(GPUCommandQueue* queue, const std::string& name, dou
     pushConstantIfValid(queue, name, value);
 }
 
+void Pipeline::pushConstant(GPUCommandQueue* queue, const std::string& name, const Vec2& value)
+{
+    pushConstantIfValid(queue, name, value);
+}
+
 void Pipeline::pushConstant(GPUCommandQueue* queue, const std::string& name, const Vec3& value)
 {
     pushConstantIfValid(queue, name, value);

--- a/src/genesis/graphics/vulkan/pipeline.cpp
+++ b/src/genesis/graphics/vulkan/pipeline.cpp
@@ -83,11 +83,11 @@ void Pipeline::bind(GPUCommandQueue* queue)
     });
 }
 
-void Pipeline::bind(GPUCommandQueue* queue, const std::string& name, GE::UniformBuffer* ubo)
+void Pipeline::bind(GPUCommandQueue* queue, const std::string& name, const GE::UniformBuffer& ubo)
 {
     VkDescriptorBufferInfo info{};
-    info.buffer = toVkBuffer(ubo->nativeHandle());
-    info.range = ubo->size();
+    info.buffer = toVkBuffer(ubo.nativeHandle());
+    info.range = ubo.size();
 
     VkWriteDescriptorSet write_descriptor_set{};
     write_descriptor_set.pBufferInfo = &info;
@@ -95,9 +95,9 @@ void Pipeline::bind(GPUCommandQueue* queue, const std::string& name, GE::Uniform
     bindResource(queue, name, &write_descriptor_set);
 }
 
-void Pipeline::bind(GPUCommandQueue* queue, const std::string& name, GE::Texture* texture)
+void Pipeline::bind(GPUCommandQueue* queue, const std::string& name, const GE::Texture& texture)
 {
-    auto* vk_texture = toVulkan(texture);
+    const auto* vk_texture = toVulkan(texture);
 
     VkDescriptorImageInfo info{};
     info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;

--- a/src/genesis/graphics/vulkan/pipeline.h
+++ b/src/genesis/graphics/vulkan/pipeline.h
@@ -74,8 +74,9 @@ public:
     ~Pipeline();
 
     void bind(GPUCommandQueue* queue) override;
-    void bind(GPUCommandQueue* queue, const std::string& name, GE::UniformBuffer* ubo) override;
-    void bind(GPUCommandQueue* queue, const std::string& name, GE::Texture* texture) override;
+    void bind(GPUCommandQueue* queue, const std::string& name,
+              const GE::UniformBuffer& ubo) override;
+    void bind(GPUCommandQueue* queue, const std::string& name, const GE::Texture& texture) override;
 
     void pushConstant(GPUCommandQueue* queue, const std::string& name, bool value) override;
     void pushConstant(GPUCommandQueue* queue, const std::string& name, int32_t value) override;

--- a/src/genesis/graphics/vulkan/pipeline.h
+++ b/src/genesis/graphics/vulkan/pipeline.h
@@ -83,6 +83,7 @@ public:
     void pushConstant(GPUCommandQueue* queue, const std::string& name, uint32_t value) override;
     void pushConstant(GPUCommandQueue* queue, const std::string& name, float value) override;
     void pushConstant(GPUCommandQueue* queue, const std::string& name, double value) override;
+    void pushConstant(GPUCommandQueue* queue, const std::string& name, const Vec2& value) override;
     void pushConstant(GPUCommandQueue* queue, const std::string& name, const Vec3& value) override;
     void pushConstant(GPUCommandQueue* queue, const std::string& name, const Mat4& value) override;
 

--- a/src/genesis/graphics/vulkan/pipeline.h
+++ b/src/genesis/graphics/vulkan/pipeline.h
@@ -62,8 +62,6 @@ struct pipeline_config_t: GE::pipeline_config_t {
     VkPipelineInputAssemblyStateCreateInfo input_assembly_state{};
     VkPipelineRasterizationStateCreateInfo rasterization_state{};
     VkPipelineMultisampleStateCreateInfo multisample_state{};
-    std::vector<VkPipelineColorBlendAttachmentState> color_blend_attachments{};
-    VkPipelineColorBlendStateCreateInfo color_blend_state{};
     VkPipelineDepthStencilStateCreateInfo depth_stencil_state{};
     std::vector<VkDynamicState> dynamic_state_list{};
     VkPipelineDynamicStateCreateInfo dynamic_state{};

--- a/src/genesis/graphics/vulkan/pipeline_resources.h
+++ b/src/genesis/graphics/vulkan/pipeline_resources.h
@@ -60,7 +60,7 @@ public:
     ~PipelineResources();
 
     std::optional<resource_descriptor_t> resource(const std::string& name) const;
-    VkDescriptorSet descriptorSet(uint32_t set) const;
+    VkDescriptorSet descriptorSet(const resource_descriptor_t& set_descriptor);
     const DescriptorSetLayouts& descriptorSetLayouts() const { return m_descriptor_set_layouts; }
 
     VkDescriptorSetLayout descriptorSetLayout(uint32_t set) const

--- a/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.cpp
+++ b/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.cpp
@@ -121,10 +121,14 @@ Scoped<GE::Pipeline> FramebufferRenderer::createPipeline(const GE::pipeline_conf
     auto vulkan_config = Vulkan::Pipeline::createDefaultConfig(config);
     vulkan_config.pipeline_cache = m_pipeline_cache;
     vulkan_config.color_formats = color_formats(m_framebuffer);
-    vulkan_config.depth_format = toVkFormat(m_framebuffer->depthTexture().format());
     vulkan_config.front_face = VK_FRONT_FACE_CLOCKWISE;
     vulkan_config.msaa_samples = toVkSampleCountFlag(m_framebuffer->MSAASamples());
     vulkan_config.descriptor_pool = m_descriptor_pool;
+
+    if (m_framebuffer->hasDepthAttachment()) {
+        vulkan_config.depth_format = toVkFormat(m_framebuffer->depthTexture().format());
+    };
+
     return tryMakeScoped<Vulkan::Pipeline>(m_device, vulkan_config);
 }
 

--- a/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.cpp
+++ b/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.cpp
@@ -101,6 +101,11 @@ void FramebufferRenderer::swapBuffers()
     m_descriptor_pool->reset();
 }
 
+Vec2 FramebufferRenderer::size() const
+{
+    return m_framebuffer->size();
+}
+
 Scoped<GE::Pipeline> FramebufferRenderer::createPipeline(const GE::pipeline_config_t& config)
 {
     auto color_formats = [](GE::Framebuffer* framebuffer) {

--- a/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.cpp
+++ b/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.cpp
@@ -89,14 +89,13 @@ bool FramebufferRenderer::beginFrame(Renderer::ClearMode clear_mode)
 
 void FramebufferRenderer::endFrame()
 {
-    VkCommandBuffer cmd = cmdBuffer();
-    m_render_command.submit(cmd);
-
-    endRendering() && submit();
+    m_render_command.submit(cmdBuffer());
+    endRendering();
 }
 
 void FramebufferRenderer::swapBuffers()
 {
+    submit();
     vkWaitForFences(m_device->device(), 1, &m_in_flight_fence, VK_TRUE,
                     std::numeric_limits<uint64_t>::max());
     m_descriptor_pool->reset();

--- a/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.cpp
+++ b/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.cpp
@@ -264,9 +264,14 @@ FramebufferRenderer::colorRenderingAttachments(ClearMode clear_mode)
     return m_framebuffer->colorRenderingAttachments(clear_mode);
 }
 
-const VkRenderingAttachmentInfo& FramebufferRenderer::depthRenderingAttachment(ClearMode clear_mode)
+std::optional<VkRenderingAttachmentInfo>
+FramebufferRenderer::depthRenderingAttachment(ClearMode clear_mode)
 {
-    return m_framebuffer->depthRenderingAttachment(clear_mode);
+    if (m_framebuffer->hasDepthAttachment()) {
+        return m_framebuffer->depthRenderingAttachment(clear_mode);
+    }
+
+    return {};
 }
 
 } // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.h
+++ b/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.h
@@ -51,6 +51,8 @@ public:
 
     void onEvent([[maybe_unused]] Event *event) override{};
 
+    Vec2 size() const override;
+
     Scoped<GE::Pipeline> createPipeline(const pipeline_config_t &config) override;
 
 private:

--- a/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.h
+++ b/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.h
@@ -70,7 +70,8 @@ private:
 
     const std::vector<VkRenderingAttachmentInfo> &
     colorRenderingAttachments(ClearMode clear_mode) override;
-    const VkRenderingAttachmentInfo &depthRenderingAttachment(ClearMode clear_mode) override;
+    std::optional<VkRenderingAttachmentInfo>
+    depthRenderingAttachment(ClearMode clear_mode) override;
 
     Vulkan::Framebuffer *m_framebuffer{nullptr};
     VkFence m_in_flight_fence{VK_NULL_HANDLE};

--- a/src/genesis/graphics/vulkan/renderers/renderer_base.cpp
+++ b/src/genesis/graphics/vulkan/renderers/renderer_base.cpp
@@ -131,7 +131,10 @@ bool RendererBase::beginRendering(ClearMode clear_mode)
     rendering_info.layerCount = 1;
     rendering_info.colorAttachmentCount = colorAttachments.size();
     rendering_info.pColorAttachments = colorAttachments.data();
-    rendering_info.pDepthAttachment = &depthAttachment;
+
+    if (depthAttachment.has_value()) {
+        rendering_info.pDepthAttachment = &depthAttachment.value();
+    }
 
     cmdBeginRendering(cmd, &rendering_info);
     return true;

--- a/src/genesis/graphics/vulkan/renderers/renderer_base.cpp
+++ b/src/genesis/graphics/vulkan/renderers/renderer_base.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "renderer_base.h"
+#include "command_buffer.h"
 #include "descriptor_pool.h"
 #include "device.h"
 #include "texture.h"
@@ -160,6 +161,15 @@ bool RendererBase::endRendering()
     }
 
     return true;
+}
+
+void RendererBase::draw(GPUCommandQueue* queue, uint32_t vertex_count, uint32_t instance_count,
+                        uint32_t first_vertex, uint32_t first_instance)
+{
+    queue->enqueue([vertex_count, instance_count, first_vertex, first_instance](void* cmd) {
+        vkCmdDraw(toVkCommandBuffer(cmd), vertex_count, instance_count, first_vertex,
+                  first_instance);
+    });
 }
 
 } // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/renderers/renderer_base.h
+++ b/src/genesis/graphics/vulkan/renderers/renderer_base.h
@@ -74,7 +74,8 @@ protected:
 
     virtual const std::vector<VkRenderingAttachmentInfo>&
     colorRenderingAttachments(ClearMode clear_mode) = 0;
-    virtual const VkRenderingAttachmentInfo& depthRenderingAttachment(ClearMode clear_mode) = 0;
+    virtual std::optional<VkRenderingAttachmentInfo>
+    depthRenderingAttachment(ClearMode clear_mode) = 0;
 
     Shared<Device> m_device;
 

--- a/src/genesis/graphics/vulkan/renderers/renderer_base.h
+++ b/src/genesis/graphics/vulkan/renderers/renderer_base.h
@@ -62,6 +62,9 @@ protected:
     void updateDynamicState();
     bool endRendering();
 
+    void draw(GPUCommandQueue* queue, uint32_t vertex_count, uint32_t instance_count,
+              uint32_t first_vertex, uint32_t first_instance) override;
+
     virtual void transitImageLayoutBeforeRendering(VkCommandBuffer cmd) = 0;
     virtual void transitImageLayoutAfterRendering(VkCommandBuffer cmd) = 0;
 
@@ -80,7 +83,7 @@ protected:
     Shared<DescriptorPool> m_descriptor_pool;
     std::vector<VkCommandBuffer> m_cmd_buffers;
 
-    RenderCommand m_render_command;
+    RenderCommand m_render_command{this};
 
 private:
     void destroyVkHandles();

--- a/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
+++ b/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
@@ -101,17 +101,13 @@ void WindowRenderer::endFrame()
 {
     VkCommandBuffer* cmd = &m_cmd_buffers[m_swap_chain->currentImageIndex()];
     m_render_command.submit(*cmd);
-
-    if (!endRendering()) {
-        return;
-    }
+    endRendering();
 }
 
 void WindowRenderer::swapBuffers()
 {
     VkCommandBuffer* cmd = &m_cmd_buffers[m_swap_chain->currentImageIndex()];
     m_swap_chain->submitCommandBuffer(cmd);
-    m_descriptor_pool->reset();
 
     auto present_result = m_swap_chain->presentImage();
 
@@ -122,6 +118,8 @@ void WindowRenderer::swapBuffers()
     } else if (present_result != VK_SUCCESS) {
         GE_CORE_ERR("Failed to present Swap Chain Image");
     }
+
+    m_descriptor_pool->reset();
 }
 
 Scoped<GE::Pipeline> WindowRenderer::createPipeline(const GE::pipeline_config_t& config)

--- a/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
+++ b/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
@@ -105,13 +105,14 @@ void WindowRenderer::endFrame()
     if (!endRendering()) {
         return;
     }
-
-    m_swap_chain->submitCommandBuffer(cmd);
-    m_descriptor_pool->reset();
 }
 
 void WindowRenderer::swapBuffers()
 {
+    VkCommandBuffer* cmd = &m_cmd_buffers[m_swap_chain->currentImageIndex()];
+    m_swap_chain->submitCommandBuffer(cmd);
+    m_descriptor_pool->reset();
+
     auto present_result = m_swap_chain->presentImage();
 
     if (present_result == VK_ERROR_OUT_OF_DATE_KHR || present_result == VK_SUBOPTIMAL_KHR ||

--- a/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
+++ b/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
@@ -260,7 +260,8 @@ WindowRenderer::colorRenderingAttachments(ClearMode clear_mode)
     return m_color_rendering_attachments;
 }
 
-const VkRenderingAttachmentInfo& WindowRenderer::depthRenderingAttachment(ClearMode clear_mode)
+std::optional<VkRenderingAttachmentInfo>
+WindowRenderer::depthRenderingAttachment(ClearMode clear_mode)
 {
     bool should_clear = clear_mode == CLEAR_DEPTH || clear_mode == CLEAR_ALL;
 

--- a/src/genesis/graphics/vulkan/renderers/window_renderer.h
+++ b/src/genesis/graphics/vulkan/renderers/window_renderer.h
@@ -86,7 +86,8 @@ private:
 
     const std::vector<VkRenderingAttachmentInfo>&
     colorRenderingAttachments(ClearMode clear_mode) override;
-    const VkRenderingAttachmentInfo& depthRenderingAttachment(ClearMode clear_mode) override;
+    std::optional<VkRenderingAttachmentInfo>
+    depthRenderingAttachment(ClearMode clear_mode) override;
 
     VkSurfaceKHR m_surface{VK_NULL_HANDLE};
     Vec2 m_window_size{0.0f, 0.0f};

--- a/src/genesis/graphics/vulkan/renderers/window_renderer.h
+++ b/src/genesis/graphics/vulkan/renderers/window_renderer.h
@@ -72,8 +72,8 @@ public:
     void onEvent(Event* event) override;
     bool onWindowResized(const WindowResizedEvent& event);
 
+    Vec2 size() const override { return m_window_size; }
     SwapChain* swapChain() const { return m_swap_chain.get(); }
-
     uint8_t MSAASamples() const { return m_msaa_samples; }
 
 private:

--- a/src/genesis/graphics/vulkan/sdl_gui_context.cpp
+++ b/src/genesis/graphics/vulkan/sdl_gui_context.cpp
@@ -181,8 +181,9 @@ void GUIContext::end()
 
 void GUIContext::draw(GPUCommandQueue *queue)
 {
-    queue->enqueue(
-        [](void *cmd) { ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), cmdBuffer(cmd)); });
+    queue->enqueue([](void *cmd) {
+        ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), toVkCommandBuffer(cmd));
+    });
 }
 
 GUI::EventHandler *GUIContext::eventHandler()

--- a/src/genesis/graphics/vulkan/shader_data_type_size.h
+++ b/src/genesis/graphics/vulkan/shader_data_type_size.h
@@ -65,6 +65,11 @@ struct data_type_traits<double> {
 };
 
 template<>
+struct data_type_traits<Vec2> {
+    static constexpr size_t SIZE{data_type_traits<Vec2::value_type>::SIZE * Vec2::length()};
+};
+
+template<>
 struct data_type_traits<Vec3> {
     static constexpr size_t SIZE{data_type_traits<Vec3::value_type>::SIZE * Vec3::length()};
 };

--- a/src/genesis/graphics/vulkan/texture.cpp
+++ b/src/genesis/graphics/vulkan/texture.cpp
@@ -174,6 +174,7 @@ Texture::Texture(Shared<Device> device, const texture_config_t& config)
     : m_device{std::move(device)}
     , m_size{config.width, config.height}
     , m_format{config.format}
+    , m_is_opaque(config.is_opaque)
 {
     createImage(config);
     createSampler(config);

--- a/src/genesis/graphics/vulkan/texture.cpp
+++ b/src/genesis/graphics/vulkan/texture.cpp
@@ -49,13 +49,18 @@ constexpr uint32_t MAX_ANISOTROPY{16};
 std::unordered_map<GE::TextureFormat, VkFormat> toVkFormatMap()
 {
     return {
+        {GE::TextureFormat::R8, VK_FORMAT_R8_UINT},
         {GE::TextureFormat::RGB8, VK_FORMAT_R8G8B8_UNORM},
         {GE::TextureFormat::RGBA8, VK_FORMAT_R8G8B8A8_UNORM},
         {GE::TextureFormat::SRGB8, VK_FORMAT_R8G8B8_SRGB},
         {GE::TextureFormat::SRGBA8, VK_FORMAT_R8G8B8A8_SRGB},
-        {GE::TextureFormat::R32F, VK_FORMAT_R32G32B32A32_SFLOAT},
+        {GE::TextureFormat::R16F, VK_FORMAT_R16_SFLOAT},
+        {GE::TextureFormat::RGBA16F, VK_FORMAT_R16G16B16A16_SFLOAT},
+        {GE::TextureFormat::R32F, VK_FORMAT_R32_SFLOAT},
+        {GE::TextureFormat::RGBA32F, VK_FORMAT_R32G32B32A32_SFLOAT},
         {GE::TextureFormat::D32F, VK_FORMAT_D32_SFLOAT},
         {GE::TextureFormat::D24S8, VK_FORMAT_D24_UNORM_S8_UINT},
+        {GE::TextureFormat::D32S8, VK_FORMAT_D32_SFLOAT_S8_UINT},
     };
 }
 

--- a/src/genesis/graphics/vulkan/texture.h
+++ b/src/genesis/graphics/vulkan/texture.h
@@ -89,9 +89,9 @@ private:
     uint32_t checkLayers(uint32_t layers) override;
 };
 
-inline Vulkan::Texture* toVulkan(GE::Texture* texture)
+inline const Vulkan::Texture* toVulkan(const GE::Texture& texture)
 {
-    return dynamic_cast<Vulkan::Texture*>(texture);
+    return dynamic_cast<const Vulkan::Texture*>(&texture);
 }
 
 VkFormat toVkFormat(TextureFormat format);

--- a/src/genesis/graphics/vulkan/texture.h
+++ b/src/genesis/graphics/vulkan/texture.h
@@ -50,6 +50,7 @@ public:
     NativeID nativeID() const override;
     const Vec2& size() const override { return m_size; }
     TextureFormat format() const override { return m_format; }
+    bool isOpaque() const override { return m_is_opaque; }
     const Scoped<Image>& image() const { return m_image; }
     VkSampler sampler() const { return m_sampler; }
 
@@ -62,6 +63,7 @@ protected:
     Scoped<Image> m_image;
     Vec2 m_size{0.0f, 0.0f};
     TextureFormat m_format{TextureFormat::UNKNOWN};
+    bool m_is_opaque{true};
     VkSampler m_sampler{VK_NULL_HANDLE};
 
     mutable VkDescriptorSet m_descriptor_set{VK_NULL_HANDLE};

--- a/src/genesis/graphics/vulkan/utils.h
+++ b/src/genesis/graphics/vulkan/utils.h
@@ -92,6 +92,11 @@ std::vector<T> vulkanGet(Func&& f, Args&&... args)
     return data;
 }
 
+constexpr VkBool32 toVkBool(bool value)
+{
+    return value ? VK_TRUE : VK_FALSE;
+}
+
 VkSampleCountFlagBits toVkSampleCountFlag(uint8_t sample_count);
 
 void cmdBeginRendering(VkCommandBuffer cmd_buffer, const VkRenderingInfo* rendering_info);

--- a/src/genesis/scene/CMakeLists.txt
+++ b/src/genesis/scene/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND SCENE_HEADERS
     ${INCLUDE_DIR}/components/yaml_convert.h
     ${INCLUDE_DIR}/renderer/irenderer.h
     ${INCLUDE_DIR}/renderer/plain_renderer.h
+    ${INCLUDE_DIR}/renderer/renderer_base.h
     )
 
 list(APPEND SCENE_SOURCES
@@ -34,6 +35,7 @@ list(APPEND SCENE_SOURCES
     camera/view_projection_camera.cpp
     camera/vp_camera_controller.cpp
     renderer/plain_renderer.cpp
+    renderer/renderer_base.cpp
     )
 
 ge_add_module(scene

--- a/src/genesis/scene/CMakeLists.txt
+++ b/src/genesis/scene/CMakeLists.txt
@@ -22,6 +22,7 @@ list(APPEND SCENE_HEADERS
     ${INCLUDE_DIR}/renderer/irenderer.h
     ${INCLUDE_DIR}/renderer/plain_renderer.h
     ${INCLUDE_DIR}/renderer/renderer_base.h
+    ${INCLUDE_DIR}/renderer/wb_oit_renderer.h
     )
 
 list(APPEND SCENE_SOURCES
@@ -36,6 +37,7 @@ list(APPEND SCENE_SOURCES
     camera/vp_camera_controller.cpp
     renderer/plain_renderer.cpp
     renderer/renderer_base.cpp
+    renderer/wb_oit_renderer.cpp
     )
 
 ge_add_module(scene

--- a/src/genesis/scene/CMakeLists.txt
+++ b/src/genesis/scene/CMakeLists.txt
@@ -19,19 +19,21 @@ list(APPEND SCENE_HEADERS
     ${INCLUDE_DIR}/components/tag_component.h
     ${INCLUDE_DIR}/components/transform_component.h
     ${INCLUDE_DIR}/components/yaml_convert.h
+    ${INCLUDE_DIR}/renderer/irenderer.h
+    ${INCLUDE_DIR}/renderer/plain_renderer.h
     )
 
 list(APPEND SCENE_SOURCES
     entity.cpp
     entity_factory.cpp
     registry.cpp
-    renderer.cpp
     scene.cpp
     scene_deserializer.cpp
     scene_serializer.cpp
     camera/projection_camera.cpp
     camera/view_projection_camera.cpp
     camera/vp_camera_controller.cpp
+    renderer/plain_renderer.cpp
     )
 
 ge_add_module(scene

--- a/src/genesis/scene/renderer/plain_renderer.cpp
+++ b/src/genesis/scene/renderer/plain_renderer.cpp
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "renderer.h"
+#include "renderer/plain_renderer.h"
 #include "camera/view_projection_camera.h"
 #include "components.h"
 #include "entity.h"
@@ -69,22 +69,26 @@ bool isValid(std::string_view entity_name, Pipeline* material, Texture* texture,
 
 } // namespace
 
-Renderer::Renderer(const ViewProjectionCamera* camera)
+PlainRenderer::PlainRenderer(const ViewProjectionCamera* camera)
     : m_camera{camera}
     , m_vp_ubo{UniformBuffer::create(sizeof(vp_t))}
     , m_translation_ubo{UniformBuffer::create(sizeof(Mat4))}
 {}
 
-Renderer::~Renderer() = default;
+PlainRenderer::~PlainRenderer() = default;
 
-void Renderer::render(GE::Renderer* renderer, const Scene& scene)
+void PlainRenderer::render(GE::Renderer* renderer, const Scene& scene)
 {
+    renderer->beginFrame();
+
     updateViewProjectionUBO();
     scene.forEach<MaterialComponent, SpriteComponent>(
         [this, renderer](const auto& entity) { renderSprite(renderer, entity); });
+
+    renderer->endFrame();
 }
 
-void Renderer::renderSprite(GE::Renderer* renderer, const GE::Scene::Entity& entity)
+void PlainRenderer::renderSprite(GE::Renderer* renderer, const GE::Scene::Entity& entity)
 {
     std::string_view entity_tag = entity.get<TagComponent>().tag;
 
@@ -108,7 +112,7 @@ void Renderer::renderSprite(GE::Renderer* renderer, const GE::Scene::Entity& ent
     cmd->draw(*mesh);
 }
 
-void Renderer::updateViewProjectionUBO()
+void PlainRenderer::updateViewProjectionUBO()
 {
     m_vp_ubo->setObject(vp_t{m_camera->view(), m_camera->projection()});
 }

--- a/src/genesis/scene/renderer/wb_oit_renderer.cpp
+++ b/src/genesis/scene/renderer/wb_oit_renderer.cpp
@@ -1,0 +1,366 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Dmitry Shilnenkov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "renderer/wb_oit_renderer.h"
+#include "camera/view_projection_camera.h"
+#include "components.h"
+#include "scene.h"
+
+#include "genesis/graphics/framebuffer.h"
+#include "genesis/graphics/graphics.h"
+#include "genesis/graphics/renderer.h"
+
+namespace GE::Scene {
+namespace {
+
+const std::string COLOR_SHADER_VERTEX = R"(
+#version 450
+
+layout(location = 0) in vec3 a_Position;
+layout(location = 1) in vec3 a_Color;
+layout(location = 2) in vec2 a_TexCoord;
+
+layout(push_constant) uniform u_PushConstants {
+    mat4 mvp;
+} pc;
+
+layout(location = 0) out vec3 v_Color;
+layout(location = 1) out vec2 v_TexCoord;
+
+void main()
+{
+    v_Color = a_Color;
+    v_TexCoord = a_TexCoord;
+    gl_Position = pc.mvp * vec4(a_Position, 1.0);
+}
+)";
+
+const std::string COLOR_SHADER_FRAGMENT = R"(
+#version 450
+
+layout(location = 0) in vec3 v_Color;
+layout(location = 1) in vec2 v_TexCoord;
+
+layout(set = 0, binding = 0) uniform sampler2D u_Sprite;
+
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    outColor = texture(u_Sprite, v_TexCoord) * vec4(v_Color, 1.0);
+}
+)";
+
+const std::string ACCUM_SHADER_FRAGMENT = R"(
+#version 450
+
+layout(location = 0) in vec3 v_Color;
+layout(location = 1) in vec2 v_TexCoord;
+
+layout(set = 0, binding = 0) uniform sampler2D u_Sprite;
+
+layout(location = 1) out vec4  outAccumColor;
+layout(location = 2) out float outReveal;
+
+void main()
+{
+    vec4 color = texture(u_Sprite, v_TexCoord) * vec4(v_Color, 1.0);
+    float z = gl_FragCoord.z;
+
+    // Calculate the weight
+    float weight = max(min(1.0, max(max(color.r, color.g), color.b) * color.a), color.a) *
+                   clamp(0.03 / (1e-5 + pow(z / 200, 4.0)), 1e-2, 3e3);
+
+    // Output the premultiplied color and the weight
+    outAccumColor = vec4(color.rgb * color.a, color.a) * weight;
+    outReveal = color.a;
+}
+)";
+
+const std::string COMPOSING_SHADER_VERTEX = R"(
+#version 450
+
+// Full-screen quad vertices
+vec2 positions[6] = vec2[](
+    vec2(-1.0, -1.0),
+    vec2(1.0, -1.0),
+    vec2(1.0, 1.0),
+    vec2(-1.0, -1.0),
+    vec2(1.0, 1.0),
+    vec2(-1.0, 1.0)
+);
+
+void main() {
+    gl_Position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
+}
+)";
+
+const std::string COMPOSING_SHADER_FRAGMENT = R"(
+#version 450
+
+layout(set = 0, binding = 0) uniform sampler2D u_ColorTex;  // Opaque color texture
+layout(set = 1, binding = 0) uniform sampler2D u_AccumTex;  // Accumulation texture
+layout(set = 2, binding = 0) uniform sampler2D u_RevealTex; // Reveal texture
+
+layout(location = 0) out vec4 outColor;
+
+// epsilon number
+const float EPSILON = 0.00001f;
+
+// calculate floating point numbers equality accurately
+bool isApproximatelyEqual(float a, float b)
+{
+    return abs(a - b) <= (abs(a) < abs(b) ? abs(b) : abs(a)) * EPSILON;
+}
+
+// get the max value between three values
+float max3(vec3 v)
+{
+    return max(max(v.x, v.y), v.z);
+}
+
+void main()
+{
+    // fragment coordination
+    ivec2 coords = ivec2(gl_FragCoord.xy);
+
+    // base color
+    outColor = texelFetch(u_ColorTex, coords, 0);
+
+    // fragment revealage
+    float revealage = texelFetch(u_RevealTex, coords, 0).r;
+
+    // save the blending and color texture fetch cost if there is not a transparent fragment
+    if (isApproximatelyEqual(revealage, 1.0f)) {
+        return;
+    }
+
+    // fragment color
+    vec4 accumulation = texelFetch(u_AccumTex, coords, 0);
+
+    // suppress overflow
+    if (isinf(max3(abs(accumulation.rgb)))) {
+        accumulation.rgb = vec3(accumulation.a);
+    }
+
+    // prevent floating point precision bug
+    vec3 average_color = accumulation.rgb / max(accumulation.a, EPSILON);
+
+    // final transparent color
+    vec4 final_color = vec4(average_color, 1.0f - revealage);
+
+    // blend with the underlying color buffer
+    outColor = mix(outColor, final_color, final_color.a);
+}
+)";
+
+bool isOpaque(const Entity& entity)
+{
+    return entity.get<SpriteComponent>().texture->isOpaque();
+}
+
+} // namespace
+
+WeightedBlendedOITRenderer::WeightedBlendedOITRenderer(GE::Renderer* renderer,
+                                                       const ViewProjectionCamera* camera)
+    : RendererBase{renderer, camera}
+{
+    createComposingPipeline(m_renderer);
+    recreateWbOitFramebuffer(m_renderer->size());
+
+    auto* wb_oit_renderer = m_wb_oit_fbo->renderer();
+    createOpaqueColorPipeline(wb_oit_renderer);
+    createAccumulationPipeline(wb_oit_renderer);
+}
+
+void WeightedBlendedOITRenderer::render(const Scene& scene)
+{
+    if (m_renderer->size() != m_wb_oit_fbo->size()) {
+        recreateWbOitFramebuffer(m_renderer->size());
+    }
+
+    auto* wb_oit_renderer = m_wb_oit_fbo->renderer();
+
+    wb_oit_renderer->beginFrame(Renderer::CLEAR_ALL);
+    renderOpaqueEntities(wb_oit_renderer, scene);
+    renderTransparentEntities(wb_oit_renderer, scene);
+    wb_oit_renderer->endFrame();
+    wb_oit_renderer->swapBuffers();
+
+    m_renderer->beginFrame(Renderer::CLEAR_ALL);
+    composeScene(m_renderer);
+    m_renderer->endFrame();
+}
+
+void WeightedBlendedOITRenderer::recreateWbOitFramebuffer(const Vec2& size)
+{
+    Framebuffer::config_t config{};
+    config.size = size;
+    config.msaa_samples = GE::Graphics::limits().max_msaa;
+    config.attachments = {
+        // Color attachment
+        {fb_attachment_t::Type::COLOR, TextureType::TEXTURE_2D, TextureFormat::SRGBA8, Vec4{0.0f}},
+        // Accumulation attachment
+        {fb_attachment_t::Type::COLOR, TextureType::TEXTURE_2D, TextureFormat::RGBA16F, Vec4{0.0f}},
+        // Reveal attachment
+        {fb_attachment_t::Type::COLOR, TextureType::TEXTURE_2D, TextureFormat::R16F, Vec4{1.0f}},
+        // Depth attachment
+        {fb_attachment_t::Type::DEPTH, TextureType::TEXTURE_2D, TextureFormat::D32F, Vec4{}, 1.0f},
+    };
+
+    m_wb_oit_fbo = Framebuffer::create(config);
+}
+
+void WeightedBlendedOITRenderer::createOpaqueColorPipeline(GE::Renderer* renderer)
+{
+    auto vertex_shader = Shader::create(Shader::Type::VERTEX);
+    GE_CORE_ASSERT(vertex_shader->compileFromSource(COLOR_SHADER_VERTEX),
+                   "Failed to compile vertex shader for accumulation pipeline");
+
+    auto fragment_shader = Shader::create(Shader::Type::FRAGMENT);
+    GE_CORE_ASSERT(fragment_shader->compileFromSource(COLOR_SHADER_FRAGMENT),
+                   "Failed to compile vertex shader for accumulation pipeline");
+
+    blending_t color_blending{};
+    color_blending.enabled = false;
+
+    pipeline_config_t config{};
+    config.vertex_shader = std::move(vertex_shader);
+    config.fragment_shader = std::move(fragment_shader);
+    config.blending = color_blending;
+    config.depth_test_enable = true;
+    config.depth_write_enable = true;
+
+    m_color_pipeline = renderer->createPipeline(config);
+    GE_CORE_ASSERT(m_color_pipeline, "Failed to create color pipeline");
+}
+
+void WeightedBlendedOITRenderer::createAccumulationPipeline(GE::Renderer* renderer)
+{
+    auto vertex_shader = Shader::create(Shader::Type::VERTEX);
+    GE_CORE_ASSERT(vertex_shader->compileFromSource(COLOR_SHADER_VERTEX),
+                   "Failed to compile vertex shader for accumulation pipeline");
+
+    auto fragment_shader = Shader::create(Shader::Type::FRAGMENT);
+    GE_CORE_ASSERT(fragment_shader->compileFromSource(ACCUM_SHADER_FRAGMENT),
+                   "Failed to compile vertex shader for accumulation pipeline");
+
+    blending_t color_blending{};
+    color_blending.enabled = false;
+
+    blending_t accum_blending{};
+    accum_blending.enabled = true;
+    accum_blending.src_color_factor = BlendFactor::ONE;
+    accum_blending.dst_color_factor = BlendFactor::ONE;
+    accum_blending.src_alpha_factor = BlendFactor::ONE;
+    accum_blending.dst_alpha_factor = BlendFactor::ONE;
+
+    blending_t reveal_blending{};
+    reveal_blending.enabled = true;
+    reveal_blending.src_color_factor = BlendFactor::ZERO;
+    reveal_blending.dst_color_factor = BlendFactor::ONE_MINUS_SRC_COLOR;
+    reveal_blending.src_alpha_factor = BlendFactor::ZERO;
+    reveal_blending.dst_alpha_factor = BlendFactor::ONE_MINUS_SRC_ALPHA;
+
+    pipeline_config_t config{};
+    config.vertex_shader = std::move(vertex_shader);
+    config.fragment_shader = std::move(fragment_shader);
+    config.blending = std::vector<blending_t>{color_blending, accum_blending, reveal_blending};
+    config.depth_test_enable = true;
+    config.depth_write_enable = false;
+
+    m_accumulation_pipeline = renderer->createPipeline(config);
+    GE_CORE_ASSERT(m_accumulation_pipeline, "Failed to create accumulation pipeline");
+}
+
+void WeightedBlendedOITRenderer::createComposingPipeline(GE::Renderer* renderer)
+{
+    auto vertex_shader = Shader::create(Shader::Type::VERTEX);
+    GE_CORE_ASSERT(vertex_shader->compileFromSource(COMPOSING_SHADER_VERTEX),
+                   "Failed to compile vertex shader for composing pipeline");
+
+    auto fragment_shader = Shader::create(Shader::Type::FRAGMENT);
+    GE_CORE_ASSERT(fragment_shader->compileFromSource(COMPOSING_SHADER_FRAGMENT),
+                   "Failed to compile vertex shader for composing pipeline");
+
+    blending_t blending{};
+    blending.enabled = true;
+    blending.src_color_factor = BlendFactor::SRC_COLOR;
+    blending.dst_color_factor = BlendFactor::ONE_MINUS_SRC_COLOR;
+    blending.src_alpha_factor = BlendFactor::SRC_ALPHA;
+    blending.dst_alpha_factor = BlendFactor::ONE_MINUS_SRC_ALPHA;
+
+    pipeline_config_t config{};
+    config.vertex_shader = std::move(vertex_shader);
+    config.fragment_shader = std::move(fragment_shader);
+    config.blending = blending;
+    config.depth_test_enable = false;
+    config.depth_write_enable = false;
+
+    m_composing_pipeline = renderer->createPipeline(config);
+    GE_CORE_ASSERT(m_composing_pipeline, "Failed to create composing pipeline");
+}
+
+void WeightedBlendedOITRenderer::renderOpaqueEntities(GE::Renderer* renderer, const Scene& scene)
+{
+    scene.forEach<SpriteComponent>([this, renderer](const auto& entity) {
+        if (isOpaque(entity)) {
+            renderEntity(renderer, m_color_pipeline.get(), entity);
+        }
+    });
+}
+
+void WeightedBlendedOITRenderer::renderTransparentEntities(GE::Renderer* renderer,
+                                                           const Scene& scene)
+{
+    scene.forEach<SpriteComponent>([this, renderer](const auto& entity) {
+        if (!isOpaque(entity)) {
+            renderEntity(renderer, m_accumulation_pipeline.get(), entity);
+        }
+    });
+}
+
+void WeightedBlendedOITRenderer::composeScene(GE::Renderer* renderer)
+{
+    auto* cmd = renderer->command();
+    auto* pipeline = m_composing_pipeline.get();
+
+    constexpr uint32_t VERTEX_COUNT{6};
+
+    cmd->bind(pipeline);
+    cmd->bind(pipeline, "u_ColorTex", m_wb_oit_fbo->colorTexture(0));
+    cmd->bind(pipeline, "u_AccumTex", m_wb_oit_fbo->colorTexture(1));
+    cmd->bind(pipeline, "u_RevealTex", m_wb_oit_fbo->colorTexture(2));
+    cmd->draw(VERTEX_COUNT, 1, 0, 0);
+}
+
+} // namespace GE::Scene

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -242,16 +242,21 @@ if (APPLE)
     # MoltenVK
     FetchContent_Declare(MoltenVK
         GIT_REPOSITORY https://github.com/hogletgames/MoltenVK.git
-        GIT_TAG v1.2.8-rc1)
-    if (NOT MoltenVK_POPULATED)
+        GIT_TAG v1.2.8)
+    FetchContent_GetProperties(MoltenVK)
+    if (NOT moltenvk_POPULATED)
         FetchContent_Populate(MoltenVK)
-        ExternalProject_Add(libMoltenVK
-            SOURCE_DIR ${moltenvk_SOURCE_DIR}
-            BUILD_IN_SOURCE ON
-            CONFIGURE_COMMAND ./fetchDependencies -v --macos
-            BUILD_COMMAND make -j${GE_NPROC} macos
-            INSTALL_COMMAND "")
-        add_dependencies(vulkan libMoltenVK)
+
+        set(MOLTENVK_ICD ${moltenvk_SOURCE_DIR}/Package/Latest/MoltenVK/dynamic/dylib/macOS/MoltenVK_icd.json)
+        add_custom_command(OUTPUT ${MOLTENVK_ICD}
+            COMMAND ./fetchDependencies -v --macos
+            COMMAND make -j${GE_NPROC} macos
+            WORKING_DIRECTORY ${moltenvk_SOURCE_DIR}
+            BYPRODUCTS ${MOLTENVK_ICD}
+            VERBATIM)
+
+        add_custom_target(MoltenVkIcd DEPENDS ${MOLTENVK_ICD})
+        add_dependencies(vulkan MoltenVkIcd)
     endif()
 endif ()
 


### PR DESCRIPTION
- Updated textures to detect transparent (opaque) objects
- Made bpending configurable during pipeline creation
- Mde depth text/depth write configurable
- Fixed a bug for mutli-binding descripror set to reuse the same desciptor set within all bidning belonging to one set
- Configure clear color per attachment
- Made depth attachment optional
- Fixed LOAD_OP for attachments, now they use `LOAD_OP_LOAD` by default
- Updated GPU  Command Queue to get rid of pipeline cache, now the commands are invoked in the order they added
- Refactored Scene Renderer to move common implementation to the base class and to rename the current renderer to PlainRenderer
- Implemented Weighted-Blended OIT Renderer