### PR TITLE
Refactor GUI lib

### DIFF
--- a/apps/level-editor/gui/level_editor_gui.cpp
+++ b/apps/level-editor/gui/level_editor_gui.cpp
@@ -81,7 +81,7 @@ void LevelEditorGUI::createPanels()
     editor_camera->open();
 
     auto viewport = GE::makeScoped<ViewportPanel>(m_ctx);
-    viewport->viewportSizeSignal()->connect(m_viewport_size_signal);
+    viewport->viewportChangedSignal()->connect(m_viewport_changed_signal);
     viewport->open();
 
     auto assets = GE::makeScoped<AssetsPanel>(m_ctx->assets());

--- a/apps/level-editor/gui/level_editor_gui.h
+++ b/apps/level-editor/gui/level_editor_gui.h
@@ -45,7 +45,7 @@ class LevelEditorContext;
 class GE_API LevelEditorGUI
 {
 public:
-    using ViewportSizeSignal = ViewportPanel::ViewportSizeSignal;
+    using ViewportChangedSignal = ViewportPanel::ViewportChangedSignal;
 
     explicit LevelEditorGUI(LevelEditorContext* ctx);
 
@@ -58,7 +58,7 @@ public:
     GE::GUI::WindowMap* panels() { return &m_panels; }
     GE::GUI::WindowMap* windows() { return &m_windows; }
 
-    ViewportSizeSignal* viewportSizeSignal() { return &m_viewport_size_signal; }
+    ViewportChangedSignal* viewportChangedSignal() { return &m_viewport_changed_signal; }
     LoadSignal* loadAssetSignal() { return m_menu_bar.loadAssetSignal(); }
     SaveSignal* saveAssetSignal() { return m_menu_bar.saveAssetSignal(); }
     LoadSignal* loadSceneSignal() { return m_menu_bar.loadSceneSignal(); }
@@ -78,7 +78,7 @@ private:
     GE::GUI::WindowMap m_windows;
     GE::GUI::ModalWindows m_modals;
 
-    ViewportSizeSignal m_viewport_size_signal;
+    ViewportChangedSignal m_viewport_changed_signal;
 };
 
 } // namespace LE

--- a/apps/level-editor/gui/main_menu/assets_menu.cpp
+++ b/apps/level-editor/gui/main_menu/assets_menu.cpp
@@ -38,7 +38,7 @@ using namespace GE::GUI;
 
 namespace LE {
 
-void AssetsMenu::onRender(GE::GUI::WidgetNodeGuard* bar_node)
+void AssetsMenu::onRender(WidgetNode* bar_node)
 {
     auto menu = bar_node->makeSubNode<Menu>("Assets");
     if (menu.call<MenuItem>("Load...")) {

--- a/apps/level-editor/gui/main_menu/assets_menu.cpp
+++ b/apps/level-editor/gui/main_menu/assets_menu.cpp
@@ -40,12 +40,11 @@ namespace LE {
 
 void AssetsMenu::onRender(GE::GUI::WidgetNodeGuard* bar_node)
 {
-    Menu menu{"Assets"};
-    auto node = bar_node->subNode(&menu);
-    if (node.call<MenuItem>("Load...")) {
+    auto menu = bar_node->makeSubNode<Menu>("Assets");
+    if (menu.call<MenuItem>("Load...")) {
         m_load_asset_signal();
     }
-    if (node.call<MenuItem>("Save as...")) {
+    if (menu.call<MenuItem>("Save as...")) {
         m_save_asset_signal();
     }
 }

--- a/apps/level-editor/gui/main_menu/assets_menu.h
+++ b/apps/level-editor/gui/main_menu/assets_menu.h
@@ -43,7 +43,7 @@ class LevelEditorContext;
 class GE_API AssetsMenu: public GE::GUI::MenuBase
 {
 public:
-    void onRender(GE::GUI::WidgetNodeGuard* bar_node) override;
+    void onRender(GE::GUI::WidgetNode* bar_node) override;
 
     LoadSignal* loadAssetSignal() { return &m_load_asset_signal; }
     SaveSignal* saveAssetSignal() { return &m_save_asset_signal; }

--- a/apps/level-editor/gui/main_menu/menu_bar.cpp
+++ b/apps/level-editor/gui/main_menu/menu_bar.cpp
@@ -66,7 +66,7 @@ void MenuBar::onEvent(GE::Event *event)
 void MenuBar::onRender()
 {
     MainMenuBar bar;
-    WidgetNodeGuard bar_node{&bar};
+    WidgetNode bar_node{&bar};
     m_menus.onRender(&bar_node);
 }
 

--- a/apps/level-editor/gui/main_menu/project_menu.cpp
+++ b/apps/level-editor/gui/main_menu/project_menu.cpp
@@ -43,7 +43,7 @@ ProjectMenu::ProjectMenu(Settings* settings)
     : m_settings{settings}
 {}
 
-void ProjectMenu::onRender(WidgetNodeGuard* bar_node)
+void ProjectMenu::onRender(WidgetNode* bar_node)
 {
     std::string_view current_project_path = m_settings->currentProject()->projectPath();
 

--- a/apps/level-editor/gui/main_menu/project_menu.cpp
+++ b/apps/level-editor/gui/main_menu/project_menu.cpp
@@ -47,23 +47,22 @@ void ProjectMenu::onRender(WidgetNodeGuard* bar_node)
 {
     std::string_view current_project_path = m_settings->currentProject()->projectPath();
 
-    Menu menu{"Project"};
-    auto project_node = bar_node->subNode(&menu);
-    if (project_node.call<MenuItem>("Load")) {
+    auto project_menu = bar_node->makeSubNode<Menu>("Project");
+    if (project_menu.call<MenuItem>("Load")) {
         m_load_signal();
     }
-    if (project_node.call<MenuItem>("Save", std::string_view{}, false,
+    if (project_menu.call<MenuItem>("Save", std::string_view{}, false,
                                     !current_project_path.empty())) {
         m_save_signal(current_project_path);
     }
-    if (project_node.call<MenuItem>("Save As...")) {
+    if (project_menu.call<MenuItem>("Save As...")) {
         m_save_as_signal();
     }
 
-    Menu recent_projects{"Recent projects", !m_settings->projectPaths().empty()};
-    auto recent_projects_node = project_node.subNode(&recent_projects);
+    auto recent_projects_menu =
+        project_menu.makeSubNode<Menu>("Recent projects", !m_settings->projectPaths().empty());
     for (const auto& [name, path] : m_settings->projectPaths()) {
-        if (recent_projects_node.call<MenuItem>(name)) {
+        if (recent_projects_menu.call<MenuItem>(name)) {
             m_load_recent_signal(path);
         }
     }

--- a/apps/level-editor/gui/main_menu/project_menu.h
+++ b/apps/level-editor/gui/main_menu/project_menu.h
@@ -45,7 +45,7 @@ class ProjectMenu: public GE::GUI::MenuBase
 public:
     explicit ProjectMenu(Settings* settings);
 
-    void onRender(GE::GUI::WidgetNodeGuard* bar_node) override;
+    void onRender(GE::GUI::WidgetNode* bar_node) override;
 
     SaveFileSignal* saveSignal() { return &m_save_signal; }
     SaveSignal* saveAsSignal() { return &m_save_as_signal; }

--- a/apps/level-editor/gui/main_menu/scene_menu.cpp
+++ b/apps/level-editor/gui/main_menu/scene_menu.cpp
@@ -38,7 +38,7 @@ using namespace GE::GUI;
 
 namespace LE {
 
-void SceneMenu::onRender(GE::GUI::WidgetNodeGuard *bar_node)
+void SceneMenu::onRender(WidgetNode *bar_node)
 {
     auto menu = bar_node->makeSubNode<Menu>("Scene");
     if (menu.call<MenuItem>("Load...")) {

--- a/apps/level-editor/gui/main_menu/scene_menu.cpp
+++ b/apps/level-editor/gui/main_menu/scene_menu.cpp
@@ -40,12 +40,11 @@ namespace LE {
 
 void SceneMenu::onRender(GE::GUI::WidgetNodeGuard *bar_node)
 {
-    Menu menu{"Scene"};
-    auto node = bar_node->subNode(&menu);
-    if (node.call<MenuItem>("Load...")) {
+    auto menu = bar_node->makeSubNode<Menu>("Scene");
+    if (menu.call<MenuItem>("Load...")) {
         m_load_scene_signal();
     }
-    if (node.call<MenuItem>("Save as...")) {
+    if (menu.call<MenuItem>("Save as...")) {
         m_save_scene_signal();
     }
 }

--- a/apps/level-editor/gui/main_menu/scene_menu.h
+++ b/apps/level-editor/gui/main_menu/scene_menu.h
@@ -41,7 +41,7 @@ namespace LE {
 class SceneMenu: public GE::GUI::MenuBase
 {
 public:
-    void onRender(GE::GUI::WidgetNodeGuard* bar_node) override;
+    void onRender(GE::GUI::WidgetNode* bar_node) override;
 
     LoadSignal* loadSceneSignal() { return &m_load_scene_signal; }
     SaveSignal* saveSceneSignal() { return &m_save_scene_signal; }

--- a/apps/level-editor/gui/main_menu/view_menu.cpp
+++ b/apps/level-editor/gui/main_menu/view_menu.cpp
@@ -43,13 +43,13 @@ ViewMenu::ViewMenu(WindowMap *panels)
     : m_panels{panels}
 {}
 
-void ViewMenu::onRender(GE::GUI::WidgetNodeGuard *bar_node)
+void ViewMenu::onRender(WidgetNode *bar_node)
 {
     auto view_menu = bar_node->makeSubNode<Menu>("View");
     drawPanels(&view_menu);
 }
 
-void ViewMenu::drawPanels(GE::GUI::WidgetNodeGuard *view_node)
+void ViewMenu::drawPanels(WidgetNode *view_node)
 {
     static constexpr std::array PANEL_NAMES = {
         EditorCameraPanel::NAME, AssetsPanel::NAME,     ViewportPanel::NAME,

--- a/apps/level-editor/gui/main_menu/view_menu.cpp
+++ b/apps/level-editor/gui/main_menu/view_menu.cpp
@@ -45,9 +45,8 @@ ViewMenu::ViewMenu(WindowMap *panels)
 
 void ViewMenu::onRender(GE::GUI::WidgetNodeGuard *bar_node)
 {
-    Menu view{"View"};
-    auto view_node = bar_node->subNode(&view);
-    drawPanels(&view_node);
+    auto view_menu = bar_node->makeSubNode<Menu>("View");
+    drawPanels(&view_menu);
 }
 
 void ViewMenu::drawPanels(GE::GUI::WidgetNodeGuard *view_node)
@@ -57,11 +56,10 @@ void ViewMenu::drawPanels(GE::GUI::WidgetNodeGuard *view_node)
         ScenePanel::NAME,        ComponentsPanel::NAME,
     };
 
-    Menu panels{"Panels"};
-    auto panels_node = view_node->subNode(&panels);
+    auto panels_menu = view_node->makeSubNode<Menu>("Panels");
     for (const char *panel_name : PANEL_NAMES) {
         if (auto *panel = m_panels->get(panel_name);
-            panels_node.call<MenuItem>(panel_name, "", panel->isOpen())) {
+            panels_menu.call<MenuItem>(panel_name, "", panel->isOpen())) {
             panel->setIsOpen(!panel->isOpen());
         }
     }

--- a/apps/level-editor/gui/main_menu/view_menu.h
+++ b/apps/level-editor/gui/main_menu/view_menu.h
@@ -42,10 +42,10 @@ class GE_API ViewMenu: public GE::GUI::MenuBase
 public:
     explicit ViewMenu(GE::GUI::WindowMap* panels);
 
-    void onRender(GE::GUI::WidgetNodeGuard* bar_node) override;
+    void onRender(GE::GUI::WidgetNode* bar_node) override;
 
 private:
-    void drawPanels(GE::GUI::WidgetNodeGuard* view_node);
+    void drawPanels(GE::GUI::WidgetNode* view_node);
 
     GE::GUI::WindowMap* m_panels;
 };

--- a/apps/level-editor/gui/modals/notification_modal.cpp
+++ b/apps/level-editor/gui/modals/notification_modal.cpp
@@ -47,7 +47,7 @@ NotificationModal::NotificationModal(const std::string& title, std::string text)
 
 void NotificationModal::onRender()
 {
-    WidgetNodeGuard window_node{&m_window};
+    WidgetNode window_node{&m_window};
     window_node.call<Text>(m_text);
     if (window_node.call<Button>("Ok")) {
         close();

--- a/apps/level-editor/gui/panels/assets_panel.cpp
+++ b/apps/level-editor/gui/panels/assets_panel.cpp
@@ -75,7 +75,7 @@ AssetsPanel::AssetsPanel(GE::Assets::Registry *registry)
 
 void AssetsPanel::onRender()
 {
-    WidgetNodeGuard window_node{&m_window};
+    WidgetNode window_node{&m_window};
     window_node.call(&AssetsPanel::updateWindowParameters, this);
     drawAssets(&window_node);
     drawContextMenu(&window_node);
@@ -86,7 +86,7 @@ void AssetsPanel::updateWindowParameters()
     m_window_size = m_window.availableRegion();
 }
 
-void AssetsPanel::drawContextMenu(AssetsPanel::NodeGuard *node)
+void AssetsPanel::drawContextMenu(WidgetNode *node)
 {
     auto flags = PopupFlag::MOUSE_BUTTON_RIGHT | PopupFlag::NO_OPEN_OVER_ITEMS |
                  PopupFlag::NO_OPEN_OVER_EXISTING_POPUP;
@@ -105,7 +105,7 @@ void AssetsPanel::drawContextMenu(AssetsPanel::NodeGuard *node)
     }
 }
 
-void AssetsPanel::drawAssets(AssetsPanel::NodeGuard *node)
+void AssetsPanel::drawAssets(WidgetNode *node)
 {
     auto ids = m_registry->ids();
     std::sort(ids.begin(), ids.end());
@@ -134,7 +134,7 @@ AssetsPanel::ResourceIDIt AssetsPanel::drawPackage(ResourceIDIt begin, ResourceI
 
         std::string_view group = it->group();
         TreeNode group_tree{group};
-        WidgetNodeGuard group_tree_node{&group_tree};
+        WidgetNode group_tree_node{&group_tree};
 
         if (group_tree_node.isOpened()) {
             it = drawGroup(it, end, package, group);
@@ -158,14 +158,14 @@ AssetsPanel::ResourceIDIt AssetsPanel::drawGroup(ResourceIDIt begin, ResourceIDI
 
         std::string_view name = it->name();
         TreeNode name_tree{name};
-        WidgetNodeGuard name_tree_node{&name_tree};
+        WidgetNode name_tree_node{&name_tree};
 
         if (name_tree_node.isOpened()) {
             m_registry->visit(*it, this);
         }
 
         PopupContextItem context{name};
-        WidgetNodeGuard context_node{&context};
+        WidgetNode context_node{&context};
         context_node.call<MenuItem>(GE_FMTSTR("Remove '{}'", it->id()));
     }
 
@@ -185,7 +185,7 @@ void AssetsPanel::visit(GE::Assets::PipelineResource *resource)
     {
         Text::call("Vertex shader: %s", resource->vertexShader().c_str());
         TreeNode code_tree{"Code:##1"};
-        WidgetNodeGuard code_node{&code_tree};
+        WidgetNode code_node{&code_tree};
         if (code_node.isOpened()) {
             auto code = GE::FS::readFile<char>(resource->vertexShader());
             Text::call(std::string_view{code.data(), code.size()});
@@ -195,7 +195,7 @@ void AssetsPanel::visit(GE::Assets::PipelineResource *resource)
     {
         Text::call("Fragment shader: %s", resource->fragmentShader().c_str());
         TreeNode code_tree{"Code:##2"};
-        WidgetNodeGuard code_node{&code_tree};
+        WidgetNode code_node{&code_tree};
         if (code_node.isOpened()) {
             auto code = GE::FS::readFile<char>(resource->fragmentShader());
             Text::call(std::string_view{code.data(), code.size()});

--- a/apps/level-editor/gui/panels/assets_panel.cpp
+++ b/apps/level-editor/gui/panels/assets_panel.cpp
@@ -133,8 +133,7 @@ AssetsPanel::ResourceIDIt AssetsPanel::drawPackage(ResourceIDIt begin, ResourceI
         }
 
         std::string_view group = it->group();
-        TreeNode group_tree{group};
-        WidgetNode group_tree_node{&group_tree};
+        auto group_tree_node = WidgetNode::create<TreeNode>(group);
 
         if (group_tree_node.isOpened()) {
             it = drawGroup(it, end, package, group);
@@ -157,16 +156,14 @@ AssetsPanel::ResourceIDIt AssetsPanel::drawGroup(ResourceIDIt begin, ResourceIDI
         }
 
         std::string_view name = it->name();
-        TreeNode name_tree{name};
-        WidgetNode name_tree_node{&name_tree};
+        auto name_tree_node = WidgetNode::create<TreeNode>(name);
 
         if (name_tree_node.isOpened()) {
             m_registry->visit(*it, this);
         }
 
-        PopupContextItem context{name};
-        WidgetNode context_node{&context};
-        context_node.call<MenuItem>(GE_FMTSTR("Remove '{}'", it->id()));
+        auto popup_context = WidgetNode::create<PopupContextItem>(name);
+        popup_context.call<MenuItem>(GE_FMTSTR("Remove '{}'", it->id()));
     }
 
     return it;
@@ -184,8 +181,7 @@ void AssetsPanel::visit(GE::Assets::PipelineResource *resource)
 
     {
         Text::call("Vertex shader: %s", resource->vertexShader().c_str());
-        TreeNode code_tree{"Code:##1"};
-        WidgetNode code_node{&code_tree};
+        auto code_node = WidgetNode::create<TreeNode>("Code:");
         if (code_node.isOpened()) {
             auto code = GE::FS::readFile<char>(resource->vertexShader());
             Text::call(std::string_view{code.data(), code.size()});
@@ -194,8 +190,7 @@ void AssetsPanel::visit(GE::Assets::PipelineResource *resource)
 
     {
         Text::call("Fragment shader: %s", resource->fragmentShader().c_str());
-        TreeNode code_tree{"Code:##2"};
-        WidgetNode code_node{&code_tree};
+        auto code_node = WidgetNode::create<TreeNode>("Code:##2");
         if (code_node.isOpened()) {
             auto code = GE::FS::readFile<char>(resource->fragmentShader());
             Text::call(std::string_view{code.data(), code.size()});

--- a/apps/level-editor/gui/panels/assets_panel.cpp
+++ b/apps/level-editor/gui/panels/assets_panel.cpp
@@ -71,16 +71,19 @@ GE::Vec2 scaledTextureSize(const GE::Vec2 &texture_size, float window_width)
 AssetsPanel::AssetsPanel(GE::Assets::Registry *registry)
     : WindowBase{NAME}
     , m_registry{registry}
-{
-    m_window.availableRegionSignal()->connect(
-        [this](const auto &region) { m_window_size = region; });
-}
+{}
 
 void AssetsPanel::onRender()
 {
     WidgetNodeGuard window_node{&m_window};
+    window_node.call(&AssetsPanel::updateWindowParameters, this);
     drawAssets(&window_node);
     drawContextMenu(&window_node);
+}
+
+void AssetsPanel::updateWindowParameters()
+{
+    m_window_size = m_window.availableRegion();
 }
 
 void AssetsPanel::drawContextMenu(AssetsPanel::NodeGuard *node)

--- a/apps/level-editor/gui/panels/assets_panel.cpp
+++ b/apps/level-editor/gui/panels/assets_panel.cpp
@@ -88,17 +88,16 @@ void AssetsPanel::drawContextMenu(AssetsPanel::NodeGuard *node)
     auto flags = PopupFlag::MOUSE_BUTTON_RIGHT | PopupFlag::NO_OPEN_OVER_ITEMS |
                  PopupFlag::NO_OPEN_OVER_EXISTING_POPUP;
 
-    PopupContextWindow context{{}, flags};
-    auto context_node = node->subNode(&context);
-    Menu add_resource{"Add resource"};
-    auto add_resource_node = context_node.subNode(&add_resource);
-    if (add_resource_node.call<MenuItem>("Mesh")) {
+    auto popup_context = node->makeSubNode<PopupContextWindow>(std::string_view{}, flags);
+    auto add_resource_menu = popup_context.makeSubNode<Menu>("Add resource");
+
+    if (add_resource_menu.call<MenuItem>("Mesh")) {
         m_add_mesh_resource_signal();
     }
-    if (add_resource_node.call<MenuItem>("Pipeline")) {
+    if (add_resource_menu.call<MenuItem>("Pipeline")) {
         m_add_pipeline_resource_signal();
     }
-    if (add_resource_node.call<MenuItem>("Texture")) {
+    if (add_resource_menu.call<MenuItem>("Texture")) {
         m_add_texture_resource_signal();
     }
 }
@@ -110,8 +109,7 @@ void AssetsPanel::drawAssets(AssetsPanel::NodeGuard *node)
 
     for (auto it = ids.cbegin(); it < ids.cend();) {
         std::string_view package = it->package();
-        TreeNode package_tree{package};
-        auto package_tree_node = node->subNode(&package_tree);
+        auto package_tree_node = node->makeSubNode<TreeNode>(package);
 
         if (package_tree_node.isOpened()) {
             it = drawPackage(it, ids.cend(), package);

--- a/apps/level-editor/gui/panels/assets_panel.h
+++ b/apps/level-editor/gui/panels/assets_panel.h
@@ -71,6 +71,8 @@ private:
     using ResourceIDIt = ResourceIDs::const_iterator;
     using NodeGuard = GE::GUI::WidgetNodeGuard;
 
+    void updateWindowParameters();
+
     void drawContextMenu(NodeGuard* node);
     void drawAssets(NodeGuard* node);
     ResourceIDIt drawPackage(ResourceIDIt begin, ResourceIDIt end, std::string_view package);

--- a/apps/level-editor/gui/panels/assets_panel.h
+++ b/apps/level-editor/gui/panels/assets_panel.h
@@ -44,7 +44,7 @@ class Registry;
 } // namespace GE::Assets
 
 namespace GE::GUI {
-class WidgetNodeGuard;
+class WidgetNode;
 } // namespace GE::GUI
 
 namespace LE {
@@ -69,12 +69,11 @@ private:
     using Registry = GE::Assets::Registry;
     using ResourceIDs = Registry::ResourceIDs;
     using ResourceIDIt = ResourceIDs::const_iterator;
-    using NodeGuard = GE::GUI::WidgetNodeGuard;
 
     void updateWindowParameters();
 
-    void drawContextMenu(NodeGuard* node);
-    void drawAssets(NodeGuard* node);
+    void drawContextMenu(GE::GUI::WidgetNode* node);
+    void drawAssets(GE::GUI::WidgetNode* node);
     ResourceIDIt drawPackage(ResourceIDIt begin, ResourceIDIt end, std::string_view package);
     AssetsPanel::ResourceIDIt drawGroup(ResourceIDIt begin, ResourceIDIt end,
                                         std::string_view package, std::string_view group);

--- a/apps/level-editor/gui/panels/components_panel.cpp
+++ b/apps/level-editor/gui/panels/components_panel.cpp
@@ -60,7 +60,7 @@ ComponentsPanel::ComponentsPanel(LevelEditorContext *ctx)
 
 void ComponentsPanel::onRender()
 {
-    WidgetNodeGuard node{&m_window};
+    WidgetNode node{&m_window};
     if (!m_ctx->selectedEntity()->isNull()) {
         drawEntityComponents(m_ctx->selectedEntity());
     }
@@ -83,11 +83,11 @@ void ComponentsPanel::draw(Entity *entity)
                  TreeNode::ALLOW_ITEM_OVERLAP | TreeNode::FRAME_PADDING;
 
     TreeNode tree{Component::NAME, flags};
-    WidgetNodeGuard tree_node{&tree};
+    WidgetNode tree_node{&tree};
     draw(&tree_node, &entity->get<Component>());
 }
 
-void ComponentsPanel::draw(GE::GUI::WidgetNodeGuard *node, GE::Scene::CameraComponent *camera)
+void ComponentsPanel::draw(WidgetNode *node, GE::Scene::CameraComponent *camera)
 {
     bool is_primary_camera = *m_ctx->selectedEntity() == m_ctx->scene()->mainCamera();
 
@@ -98,7 +98,7 @@ void ComponentsPanel::draw(GE::GUI::WidgetNodeGuard *node, GE::Scene::CameraComp
     node->call<Checkbox>("Fixed aspect ratio", &camera->fixed_aspect_ratio);
 }
 
-void ComponentsPanel::draw(WidgetNodeGuard *node, MaterialComponent *material)
+void ComponentsPanel::draw(WidgetNode *node, MaterialComponent *material)
 {
     auto material_id = material->materialID().id();
 
@@ -108,12 +108,12 @@ void ComponentsPanel::draw(WidgetNodeGuard *node, MaterialComponent *material)
     }
 }
 
-void ComponentsPanel::draw(WidgetNodeGuard *node, TagComponent *tag)
+void ComponentsPanel::draw(WidgetNode *node, TagComponent *tag)
 {
     node->call<Text>("Tag: %s", tag->tag.c_str());
 }
 
-void ComponentsPanel::draw(WidgetNodeGuard *node, TransformComponent *transform)
+void ComponentsPanel::draw(WidgetNode *node, TransformComponent *transform)
 {
     node->call<ValueEditor>("Translation", &transform->translation, 0.05f, -10.0f, 10.0f);
     if (auto angles = GE::degrees(transform->rotation);
@@ -123,7 +123,7 @@ void ComponentsPanel::draw(WidgetNodeGuard *node, TransformComponent *transform)
     node->call<ValueEditor>("Scale", &transform->scale, 0.1, 0.0f, 10.0f);
 }
 
-void ComponentsPanel::draw(WidgetNodeGuard *node, SpriteComponent *sprite)
+void ComponentsPanel::draw(WidgetNode *node, SpriteComponent *sprite)
 {
     auto mesh_id = sprite->meshID().id();
     auto texture_id = sprite->textureID().id();

--- a/apps/level-editor/gui/panels/components_panel.cpp
+++ b/apps/level-editor/gui/panels/components_panel.cpp
@@ -82,8 +82,7 @@ void ComponentsPanel::draw(Entity *entity)
     auto flags = TreeNode::DEFAULT_OPEN | TreeNode::FRAMED | TreeNode::SPAN_AVAIL_WIDTH |
                  TreeNode::ALLOW_ITEM_OVERLAP | TreeNode::FRAME_PADDING;
 
-    TreeNode tree{Component::NAME, flags};
-    WidgetNode tree_node{&tree};
+    auto tree_node = WidgetNode::create<TreeNode>(Component::NAME, flags);
     draw(&tree_node, &entity->get<Component>());
 }
 

--- a/apps/level-editor/gui/panels/components_panel.h
+++ b/apps/level-editor/gui/panels/components_panel.h
@@ -35,7 +35,7 @@
 #include <genesis/gui/window/window_base.h>
 
 namespace GE::GUI {
-class WidgetNodeGuard;
+class WidgetNode;
 } // namespace GE::GUI
 
 namespace GE::Scene {
@@ -64,11 +64,11 @@ private:
     void drawEntityComponents(GE::Scene::Entity* entity);
     template<typename Component>
     void draw(GE::Scene::Entity* entity);
-    void draw(GE::GUI::WidgetNodeGuard* node, GE::Scene::CameraComponent* camera);
-    void draw(GE::GUI::WidgetNodeGuard* node, GE::Scene::MaterialComponent* material);
-    void draw(GE::GUI::WidgetNodeGuard* node, GE::Scene::TagComponent* tag);
-    void draw(GE::GUI::WidgetNodeGuard* node, GE::Scene::TransformComponent* transform);
-    void draw(GE::GUI::WidgetNodeGuard* node, GE::Scene::SpriteComponent* sprite);
+    void draw(GE::GUI::WidgetNode* node, GE::Scene::CameraComponent* camera);
+    void draw(GE::GUI::WidgetNode* node, GE::Scene::MaterialComponent* material);
+    void draw(GE::GUI::WidgetNode* node, GE::Scene::TagComponent* tag);
+    void draw(GE::GUI::WidgetNode* node, GE::Scene::TransformComponent* transform);
+    void draw(GE::GUI::WidgetNode* node, GE::Scene::SpriteComponent* sprite);
 
     LevelEditorContext* m_ctx{nullptr};
 };

--- a/apps/level-editor/gui/panels/editor_camera_panel.cpp
+++ b/apps/level-editor/gui/panels/editor_camera_panel.cpp
@@ -74,11 +74,13 @@ void EditorCameraPanel::drawProjectionCombo(::WidgetNodeGuard *node)
         GE::toString(GE::Scene::ViewProjectionCamera::PERSPECTIVE),
     };
 
-    ComboBox combo{"Projection type", PROJECTIONS, GE::toString(m_camera->type())};
-    combo.itemChangedSignal()->connect([this](std::string_view projection) {
-        m_camera->setType(GE::Scene::toProjectionType(projection));
-    });
+    auto current_projection = GE::toString(m_camera->type());
+    ComboBox combo{"Projection type", PROJECTIONS, current_projection};
     node->subNode(&combo);
+
+    if (combo.selectedItem() != current_projection) {
+        m_camera->setType(GE::Scene::toProjectionType(combo.selectedItem()));
+    }
 }
 
 void EditorCameraPanel::drawPerspectiveProjection(::WidgetNodeGuard *node)

--- a/apps/level-editor/gui/panels/editor_camera_panel.cpp
+++ b/apps/level-editor/gui/panels/editor_camera_panel.cpp
@@ -74,7 +74,7 @@ void EditorCameraPanel::drawProjectionCombo(::WidgetNodeGuard *node)
         GE::toString(GE::Scene::ViewProjectionCamera::PERSPECTIVE),
     };
 
-    ::ComboBox combo{"Projection type", PROJECTIONS, GE::toString(m_camera->type())};
+    ComboBox combo{"Projection type", PROJECTIONS, GE::toString(m_camera->type())};
     combo.itemChangedSignal()->connect([this](std::string_view projection) {
         m_camera->setType(GE::Scene::toProjectionType(projection));
     });

--- a/apps/level-editor/gui/panels/editor_camera_panel.cpp
+++ b/apps/level-editor/gui/panels/editor_camera_panel.cpp
@@ -54,7 +54,7 @@ void EditorCameraPanel::onRender()
     drawReadOnlyOptions(&node);
 }
 
-void EditorCameraPanel::drawView(::WidgetNode *node)
+void EditorCameraPanel::drawView(WidgetNode *node)
 {
     if (auto position = m_camera->position();
         node->call<::ValueEditor>("Position", &position, 0.1f, -100.0f, 100.0f)) {
@@ -67,7 +67,7 @@ void EditorCameraPanel::drawView(::WidgetNode *node)
     }
 }
 
-void EditorCameraPanel::drawProjectionCombo(::WidgetNode *node)
+void EditorCameraPanel::drawProjectionCombo(WidgetNode *node)
 {
     static const std::vector<std::string> PROJECTIONS = {
         GE::toString(GE::Scene::ViewProjectionCamera::ORTHOGRAPHIC),
@@ -83,7 +83,7 @@ void EditorCameraPanel::drawProjectionCombo(::WidgetNode *node)
     }
 }
 
-void EditorCameraPanel::drawPerspectiveProjection(::WidgetNode *node)
+void EditorCameraPanel::drawPerspectiveProjection(WidgetNode *node)
 {
     auto [fov, near, far] = m_camera->perspectiveOptions();
     node->call<::ValueEditor>("Field of view", &fov, 0.1f, 0.0f, 180.0f);
@@ -93,7 +93,7 @@ void EditorCameraPanel::drawPerspectiveProjection(::WidgetNode *node)
     m_camera->setPerspectiveOptions({fov, near, far});
 }
 
-void EditorCameraPanel::drawOrthoProjection(::WidgetNode *node)
+void EditorCameraPanel::drawOrthoProjection(WidgetNode *node)
 {
     auto [size, near, far] = m_camera->orthographicOptions();
     node->call<::ValueEditor>("Size", &size, 0.1f, 0.0f, 10.0f);
@@ -103,7 +103,7 @@ void EditorCameraPanel::drawOrthoProjection(::WidgetNode *node)
     m_camera->setOrthoOptions({size, near, far});
 }
 
-void EditorCameraPanel::drawProjectionOptions(::WidgetNode *node)
+void EditorCameraPanel::drawProjectionOptions(WidgetNode *node)
 {
     switch (m_camera->type()) {
         case GE::Scene::ViewProjectionCamera::PERSPECTIVE: drawPerspectiveProjection(node); break;
@@ -112,7 +112,7 @@ void EditorCameraPanel::drawProjectionOptions(::WidgetNode *node)
     }
 }
 
-void EditorCameraPanel::drawReadOnlyOptions(::WidgetNode *node)
+void EditorCameraPanel::drawReadOnlyOptions(WidgetNode *node)
 {
     node->call<::Text>("Direction: %s", GE::toString(m_camera->direction()).c_str());
 }

--- a/apps/level-editor/gui/panels/editor_camera_panel.cpp
+++ b/apps/level-editor/gui/panels/editor_camera_panel.cpp
@@ -47,14 +47,14 @@ EditorCameraPanel::EditorCameraPanel(GE::Scene::ViewProjectionCamera *camera)
 
 void EditorCameraPanel::onRender()
 {
-    WidgetNodeGuard node{&m_window};
+    WidgetNode node{&m_window};
     drawView(&node);
     drawProjectionCombo(&node);
     drawProjectionOptions(&node);
     drawReadOnlyOptions(&node);
 }
 
-void EditorCameraPanel::drawView(::WidgetNodeGuard *node)
+void EditorCameraPanel::drawView(::WidgetNode *node)
 {
     if (auto position = m_camera->position();
         node->call<::ValueEditor>("Position", &position, 0.1f, -100.0f, 100.0f)) {
@@ -67,7 +67,7 @@ void EditorCameraPanel::drawView(::WidgetNodeGuard *node)
     }
 }
 
-void EditorCameraPanel::drawProjectionCombo(::WidgetNodeGuard *node)
+void EditorCameraPanel::drawProjectionCombo(::WidgetNode *node)
 {
     static const std::vector<std::string> PROJECTIONS = {
         GE::toString(GE::Scene::ViewProjectionCamera::ORTHOGRAPHIC),
@@ -83,7 +83,7 @@ void EditorCameraPanel::drawProjectionCombo(::WidgetNodeGuard *node)
     }
 }
 
-void EditorCameraPanel::drawPerspectiveProjection(::WidgetNodeGuard *node)
+void EditorCameraPanel::drawPerspectiveProjection(::WidgetNode *node)
 {
     auto [fov, near, far] = m_camera->perspectiveOptions();
     node->call<::ValueEditor>("Field of view", &fov, 0.1f, 0.0f, 180.0f);
@@ -93,7 +93,7 @@ void EditorCameraPanel::drawPerspectiveProjection(::WidgetNodeGuard *node)
     m_camera->setPerspectiveOptions({fov, near, far});
 }
 
-void EditorCameraPanel::drawOrthoProjection(::WidgetNodeGuard *node)
+void EditorCameraPanel::drawOrthoProjection(::WidgetNode *node)
 {
     auto [size, near, far] = m_camera->orthographicOptions();
     node->call<::ValueEditor>("Size", &size, 0.1f, 0.0f, 10.0f);
@@ -103,7 +103,7 @@ void EditorCameraPanel::drawOrthoProjection(::WidgetNodeGuard *node)
     m_camera->setOrthoOptions({size, near, far});
 }
 
-void EditorCameraPanel::drawProjectionOptions(::WidgetNodeGuard *node)
+void EditorCameraPanel::drawProjectionOptions(::WidgetNode *node)
 {
     switch (m_camera->type()) {
         case GE::Scene::ViewProjectionCamera::PERSPECTIVE: drawPerspectiveProjection(node); break;
@@ -112,7 +112,7 @@ void EditorCameraPanel::drawProjectionOptions(::WidgetNodeGuard *node)
     }
 }
 
-void EditorCameraPanel::drawReadOnlyOptions(::WidgetNodeGuard *node)
+void EditorCameraPanel::drawReadOnlyOptions(::WidgetNode *node)
 {
     node->call<::Text>("Direction: %s", GE::toString(m_camera->direction()).c_str());
 }

--- a/apps/level-editor/gui/panels/editor_camera_panel.h
+++ b/apps/level-editor/gui/panels/editor_camera_panel.h
@@ -35,7 +35,7 @@
 #include <genesis/gui/window/window_base.h>
 
 namespace GE::GUI {
-class WidgetNodeGuard;
+class WidgetNode;
 } // namespace GE::GUI
 
 namespace GE::Scene {
@@ -54,12 +54,12 @@ public:
     static constexpr auto NAME{"Editor camera"};
 
 private:
-    void drawView(GE::GUI::WidgetNodeGuard* node);
-    void drawProjectionCombo(GE::GUI::WidgetNodeGuard* node);
-    void drawPerspectiveProjection(GE::GUI::WidgetNodeGuard* node);
-    void drawOrthoProjection(GE::GUI::WidgetNodeGuard* node);
-    void drawProjectionOptions(GE::GUI::WidgetNodeGuard* node);
-    void drawReadOnlyOptions(GE::GUI::WidgetNodeGuard* node);
+    void drawView(GE::GUI::WidgetNode* node);
+    void drawProjectionCombo(GE::GUI::WidgetNode* node);
+    void drawPerspectiveProjection(GE::GUI::WidgetNode* node);
+    void drawOrthoProjection(GE::GUI::WidgetNode* node);
+    void drawProjectionOptions(GE::GUI::WidgetNode* node);
+    void drawReadOnlyOptions(GE::GUI::WidgetNode* node);
 
     GE::Scene::ViewProjectionCamera* m_camera{nullptr};
 };

--- a/apps/level-editor/gui/panels/log_panel.cpp
+++ b/apps/level-editor/gui/panels/log_panel.cpp
@@ -126,13 +126,13 @@ void LogPanel::onRender()
 {
     StyleVar padding{StyleVar::WINDOW_PADDING, {0.0f, 0.0f}};
 
-    if (WidgetNodeGuard node{&m_window}; node.isOpened()) {
+    if (WidgetNode node{&m_window}; node.isOpened()) {
         drawControls(&node);
         drawLogs(&node);
     }
 }
 
-void LogPanel::drawControls(WidgetNodeGuard *node)
+void LogPanel::drawControls(WidgetNode *node)
 {
     if (node->call<Button>("Clear")) {
         m_log_sink->clear();
@@ -148,7 +148,7 @@ void LogPanel::drawControls(WidgetNodeGuard *node)
     }
 }
 
-void LogPanel::drawLogs(WidgetNodeGuard *node)
+void LogPanel::drawLogs(WidgetNode *node)
 {
     auto logs = m_log_sink->lines();
     auto log_lines = GE::joinString(logs.begin(), logs.end());

--- a/apps/level-editor/gui/panels/log_panel.cpp
+++ b/apps/level-editor/gui/panels/log_panel.cpp
@@ -139,10 +139,13 @@ void LogPanel::drawControls(WidgetNodeGuard *node)
     }
     node->call<SameLine>();
 
-    ComboBox level{"level", LEVELS, toString(m_log_sink->level())};
-    level.itemChangedSignal()->connect(
-        [this](std::string_view value) { m_log_sink->set_level(toSpdlogLevel(value)); });
+    auto level_string = toString(m_log_sink->level());
+    ComboBox level{"level", LEVELS, level_string};
     node->subNode(&level);
+
+    if (level.selectedItem() != level_string) {
+        m_log_sink->set_level(toSpdlogLevel(level.selectedItem()));
+    }
 }
 
 void LogPanel::drawLogs(WidgetNodeGuard *node)

--- a/apps/level-editor/gui/panels/log_panel.h
+++ b/apps/level-editor/gui/panels/log_panel.h
@@ -37,7 +37,7 @@
 #include <memory>
 
 namespace GE::GUI {
-class WidgetNodeGuard;
+class WidgetNode;
 } // namespace GE::GUI
 
 namespace LE {
@@ -53,8 +53,8 @@ public:
     static constexpr auto NAME{"Log"};
 
 private:
-    void drawControls(GE::GUI::WidgetNodeGuard* node);
-    void drawLogs(GE::GUI::WidgetNodeGuard* node);
+    void drawControls(GE::GUI::WidgetNode* node);
+    void drawLogs(GE::GUI::WidgetNode* node);
 
     class LogSink;
     std::shared_ptr<LogSink> m_log_sink;

--- a/apps/level-editor/gui/panels/scene_panel.cpp
+++ b/apps/level-editor/gui/panels/scene_panel.cpp
@@ -49,12 +49,12 @@ ScenePanel::ScenePanel(LevelEditorContext* ctx)
 
 void ScenePanel::onRender()
 {
-    WidgetNodeGuard node{&m_window};
+    WidgetNode node{&m_window};
     drawScene(&node);
     drawContextMenu(&node);
 }
 
-void ScenePanel::drawScene(WidgetNodeGuard* node)
+void ScenePanel::drawScene(WidgetNode* node)
 {
     m_ctx->scene()->forEachEntity([this, node](const auto& entity) { drawEntity(node, entity); });
 
@@ -63,7 +63,7 @@ void ScenePanel::drawScene(WidgetNodeGuard* node)
     }
 }
 
-void ScenePanel::drawEntity(WidgetNodeGuard* node, const Entity& entity)
+void ScenePanel::drawEntity(WidgetNode* node, const Entity& entity)
 {
     auto flags = TreeNode::OPEN_ON_ARROW | TreeNode::SPAN_AVAIL_WIDTH;
     bool remove_entity{false};
@@ -76,7 +76,7 @@ void ScenePanel::drawEntity(WidgetNodeGuard* node, const Entity& entity)
 
     {
         auto entity_tree_node = node->makeSubNode<TreeNode>(tag, flags);
-        auto popup_context = WidgetNodeGuard::create<PopupContextItem>();
+        auto popup_context = WidgetNode::create<PopupContextItem>();
 
         if (popup_context.call<MenuItem>(GE_FMTSTR("Remove '{}'", tag))) {
             remove_entity = true;
@@ -92,7 +92,7 @@ void ScenePanel::drawEntity(WidgetNodeGuard* node, const Entity& entity)
     }
 }
 
-void ScenePanel::drawContextMenu(WidgetNodeGuard* node)
+void ScenePanel::drawContextMenu(WidgetNode* node)
 {
     EntityFactory entity_factory{m_ctx->scene(), m_ctx->assets()};
     auto flags = PopupFlag::MOUSE_BUTTON_RIGHT | PopupFlag::NO_OPEN_OVER_EXISTING_POPUP;

--- a/apps/level-editor/gui/panels/scene_panel.cpp
+++ b/apps/level-editor/gui/panels/scene_panel.cpp
@@ -73,12 +73,12 @@ void ScenePanel::drawEntity(WidgetNodeGuard* node, const Entity& entity)
     }
 
     std::string_view tag = entity.get<TagComponent>().tag;
-    TreeNode entity_tree{tag, flags};
+
     {
-        auto entity_node = node->subNode(&entity_tree);
-        PopupContextItem context_menu;
-        WidgetNodeGuard context_menu_node{&context_menu};
-        if (context_menu_node.call<MenuItem>(GE_FMTSTR("Remove '{}'", tag))) {
+        auto entity_tree_node = node->makeSubNode<TreeNode>(tag, flags);
+        auto popup_context = WidgetNodeGuard::create<PopupContextItem>();
+
+        if (popup_context.call<MenuItem>(GE_FMTSTR("Remove '{}'", tag))) {
             remove_entity = true;
         }
 
@@ -97,20 +97,19 @@ void ScenePanel::drawContextMenu(WidgetNodeGuard* node)
     EntityFactory entity_factory{m_ctx->scene(), m_ctx->assets()};
     auto flags = PopupFlag::MOUSE_BUTTON_RIGHT | PopupFlag::NO_OPEN_OVER_EXISTING_POPUP;
 
-    PopupContextWindow context_menu{{}, flags};
-    auto context_menu_node = node->subNode(&context_menu);
-    Menu add_entity_menu{"Add entity"};
-    auto add_entity_node = context_menu_node.subNode(&add_entity_menu);
-    if (add_entity_node.call<MenuItem>("Circle")) {
+    auto context_menu_node = node->makeSubNode<PopupContextWindow>(std::string_view{}, flags);
+    auto add_entity_menu = context_menu_node.makeSubNode<Menu>("Add entity");
+
+    if (add_entity_menu.call<MenuItem>("Circle")) {
         entity_factory.createCircle("Circle");
     }
-    if (add_entity_node.call<MenuItem>("Square")) {
+    if (add_entity_menu.call<MenuItem>("Square")) {
         entity_factory.createSquare("Square");
     }
-    if (add_entity_node.call<MenuItem>("Empty entity")) {
+    if (add_entity_menu.call<MenuItem>("Empty entity")) {
         entity_factory.createEmptyEntity("Entity");
     }
-    if (add_entity_node.call<MenuItem>("Camera")) {
+    if (add_entity_menu.call<MenuItem>("Camera")) {
         entity_factory.createCamera("Camera");
     }
 }

--- a/apps/level-editor/gui/panels/scene_panel.h
+++ b/apps/level-editor/gui/panels/scene_panel.h
@@ -35,7 +35,7 @@
 #include <genesis/gui/window/window_base.h>
 
 namespace GE::GUI {
-class WidgetNodeGuard;
+class WidgetNode;
 } // namespace GE::GUI
 
 namespace GE::Scene {
@@ -56,9 +56,9 @@ public:
     static constexpr auto NAME{"Scene"};
 
 private:
-    void drawScene(GE::GUI::WidgetNodeGuard* node);
-    void drawEntity(GE::GUI::WidgetNodeGuard* node, const GE::Scene::Entity& entity);
-    void drawContextMenu(GE::GUI::WidgetNodeGuard* node);
+    void drawScene(GE::GUI::WidgetNode* node);
+    void drawEntity(GE::GUI::WidgetNode* node, const GE::Scene::Entity& entity);
+    void drawContextMenu(GE::GUI::WidgetNode* node);
 
     void removeEntity(const GE::Scene::Entity& entity);
 

--- a/apps/level-editor/gui/panels/viewport_panel.cpp
+++ b/apps/level-editor/gui/panels/viewport_panel.cpp
@@ -72,7 +72,7 @@ void ViewportPanel::onRender()
 {
     StyleVar padding{StyleVar::WINDOW_PADDING, {0.0f, 0.0f}};
 
-    WidgetNodeGuard window{&m_window};
+    WidgetNode window{&m_window};
 
     auto& scene_fbo = m_ctx->sceneFbo();
     scene_fbo->renderer()->swapBuffers();

--- a/apps/level-editor/gui/panels/viewport_panel.h
+++ b/apps/level-editor/gui/panels/viewport_panel.h
@@ -36,6 +36,8 @@
 #include <genesis/gui/window/window_base.h>
 #include <genesis/math/types.h>
 
+#include <boost/signals2/signal.hpp>
+
 namespace GE {
 class Event;
 class MouseButtonReleasedEvent;
@@ -52,7 +54,7 @@ class LevelEditorContext;
 class GE_API ViewportPanel: public GE::GUI::WindowBase
 {
 public:
-    using ViewportSizeSignal = GE::GUI::Window::AvailableRegionSignal;
+    using ViewportChangedSignal = boost::signals2::signal<void(const GE::Vec2&)>;
 
     explicit ViewportPanel(LevelEditorContext* ctx);
 
@@ -60,12 +62,14 @@ public:
     void onEvent(GE::Event* event) override;
     void onRender() override;
 
-    ViewportSizeSignal* viewportSizeSignal() { return m_window.availableRegionSignal(); }
+    ViewportChangedSignal* viewportChangedSignal() { return &m_viewport_changed_signal; }
 
     static constexpr auto NAME{"Viewport"};
 
 private:
     bool isPanelActive() const { return m_is_focused || m_is_hovered; }
+
+    void updateWindowParameters();
 
     void drawGizmos(GE::Scene::Entity* entity);
 
@@ -73,7 +77,7 @@ private:
 
     LevelEditorContext* m_ctx{nullptr};
     GE::Vec2 m_viewport{0.0f, 0.0f};
-    ViewportSizeSignal m_viewport_changed;
+    ViewportChangedSignal m_viewport_changed_signal;
 
     bool m_is_focused{false};
     bool m_is_hovered{false};

--- a/apps/level-editor/gui/windows/add_mesh_resource_window.cpp
+++ b/apps/level-editor/gui/windows/add_mesh_resource_window.cpp
@@ -49,7 +49,7 @@ AddMeshResourceWindow::AddMeshResourceWindow(LevelEditorContext* ctx)
 
 void AddMeshResourceWindow::onRender()
 {
-    WidgetNodeGuard node{&m_window};
+    WidgetNode node{&m_window};
     node.call<InputText>("Package", m_id.package());
     node.call<InputText>("Group", m_id.group());
     node.call<InputText>("Name", m_id.name());

--- a/apps/level-editor/gui/windows/add_mesh_resource_window.h
+++ b/apps/level-editor/gui/windows/add_mesh_resource_window.h
@@ -36,6 +36,8 @@
 #include <genesis/gui/widgets/window.h>
 #include <genesis/gui/window/window_base.h>
 
+#include <boost/signals2/signal.hpp>
+
 namespace LE {
 
 class LevelEditorContext;

--- a/apps/level-editor/gui/windows/add_pipeline_resources_window.cpp
+++ b/apps/level-editor/gui/windows/add_pipeline_resources_window.cpp
@@ -50,7 +50,7 @@ AddPipelineResourceWindow::AddPipelineResourceWindow(LevelEditorContext* ctx)
 
 void AddPipelineResourceWindow::onRender()
 {
-    WidgetNodeGuard node{&m_window};
+    WidgetNode node{&m_window};
     node.call<InputText>("Package", m_id.package());
     node.call<InputText>("Group", m_id.group());
     node.call<InputText>("Name", m_id.name());

--- a/apps/level-editor/gui/windows/add_texture_resource_window.cpp
+++ b/apps/level-editor/gui/windows/add_texture_resource_window.cpp
@@ -49,7 +49,7 @@ AddTextureResourceWindow::AddTextureResourceWindow(LevelEditorContext* ctx)
 
 void AddTextureResourceWindow::onRender()
 {
-    WidgetNodeGuard node{&m_window};
+    WidgetNode node{&m_window};
     node.call<InputText>("Package", m_id.package());
     node.call<InputText>("Group", m_id.group());
     node.call<InputText>("Name", m_id.name());

--- a/apps/level-editor/gui/windows/add_texture_resource_window.h
+++ b/apps/level-editor/gui/windows/add_texture_resource_window.h
@@ -36,6 +36,8 @@
 #include <genesis/gui/widgets/window.h>
 #include <genesis/gui/window/window_base.h>
 
+#include <boost/signals2/signal.hpp>
+
 namespace LE {
 
 class LevelEditorContext;

--- a/apps/level-editor/level_editor.cpp
+++ b/apps/level-editor/level_editor.cpp
@@ -122,7 +122,8 @@ void LevelEditor::createSceneRenderer()
 
 void LevelEditor::connectSignals()
 {
-    m_gui->viewportSizeSignal()->connect([this](const auto& viewport) { m_viewport = viewport; });
+    m_gui->viewportChangedSignal()->connect(
+        [this](const auto& viewport) { m_viewport = viewport; });
     m_gui->loadAssetSignal()->connect([this] { onLoadAssets(); });
     m_gui->saveAssetSignal()->connect([this] { onSaveAssets(); });
     m_gui->loadSceneSignal()->connect([this] { onLoadScene(); });

--- a/examples/sandbox/gui_layer/gui_layer.cpp
+++ b/examples/sandbox/gui_layer/gui_layer.cpp
@@ -118,14 +118,14 @@ void drawReadOnlyOptions(GE::GUI::WidgetNodeGuard* node,
 
 void drawCameraOptions(GE::GUI::WidgetNodeGuard* parent, GE::Examples::GuiLayerWindow* window)
 {
-    GE::GUI::TreeNode camera_tree{window->name(), GE::GUI::TreeNode::FRAMED};
-    auto node = parent->subNode(&camera_tree);
+    auto camera_tree_node =
+        parent->makeSubNode<GE::GUI::TreeNode>(window->name(), GE::GUI::TreeNode::FRAMED);
     auto camera = window->camera();
 
-    drawView(&node, camera);
-    drawProjectionCombo(&node, camera);
-    drawProjectionOptions(&node, camera);
-    drawReadOnlyOptions(&node, camera);
+    drawView(&camera_tree_node, camera);
+    drawProjectionCombo(&camera_tree_node, camera);
+    drawProjectionOptions(&camera_tree_node, camera);
+    drawReadOnlyOptions(&camera_tree_node, camera);
 }
 
 } // namespace

--- a/examples/sandbox/gui_layer/gui_layer.cpp
+++ b/examples/sandbox/gui_layer/gui_layer.cpp
@@ -46,8 +46,7 @@ namespace {
 constexpr auto VIKING_ROOM_MODEL{"examples/sdl2-vulkan/models/viking_room.obj"};
 constexpr auto VIKING_ROOM_TEXTURE{"examples/sandbox/assets/textures/viking_room.png"};
 
-void drawView(GE::GUI::WidgetNodeGuard* node,
-              const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
+void drawView(GE::GUI::WidgetNode* node, const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     if (auto position = camera->position();
         node->call<GE::GUI::ValueEditor>("Position", &position, 1.0f, -100.0f, 100.0f)) {
@@ -60,7 +59,7 @@ void drawView(GE::GUI::WidgetNodeGuard* node,
     }
 }
 
-void drawProjectionCombo(GE::GUI::WidgetNodeGuard* node,
+void drawProjectionCombo(GE::GUI::WidgetNode* node,
                          const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     static const std::vector<std::string> PROJECTIONS = {
@@ -77,7 +76,7 @@ void drawProjectionCombo(GE::GUI::WidgetNodeGuard* node,
     }
 }
 
-void drawPerspectiveProjection(GE::GUI::WidgetNodeGuard* node,
+void drawPerspectiveProjection(GE::GUI::WidgetNode* node,
                                const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     auto [fov, near, far] = camera->perspectiveOptions();
@@ -88,7 +87,7 @@ void drawPerspectiveProjection(GE::GUI::WidgetNodeGuard* node,
     camera->setPerspectiveOptions({fov, near, far});
 }
 
-void drawOrthoProjection(GE::GUI::WidgetNodeGuard* node,
+void drawOrthoProjection(GE::GUI::WidgetNode* node,
                          const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     auto [size, near, far] = camera->orthographicOptions();
@@ -99,7 +98,7 @@ void drawOrthoProjection(GE::GUI::WidgetNodeGuard* node,
     camera->setOrthoOptions({size, near, far});
 }
 
-void drawProjectionOptions(GE::GUI::WidgetNodeGuard* node,
+void drawProjectionOptions(GE::GUI::WidgetNode* node,
                            const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     switch (camera->type()) {
@@ -112,13 +111,13 @@ void drawProjectionOptions(GE::GUI::WidgetNodeGuard* node,
     }
 }
 
-void drawReadOnlyOptions(GE::GUI::WidgetNodeGuard* node,
+void drawReadOnlyOptions(GE::GUI::WidgetNode* node,
                          const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     node->call<GE::GUI::Text>("Direction: %s", GE::toString(camera->direction()).c_str());
 }
 
-void drawCameraOptions(GE::GUI::WidgetNodeGuard* parent, GE::Examples::GuiLayerWindow* window)
+void drawCameraOptions(GE::GUI::WidgetNode* parent, GE::Examples::GuiLayerWindow* window)
 {
     auto camera_tree_node =
         parent->makeSubNode<GE::GUI::TreeNode>(window->name(), GE::GUI::TreeNode::FRAMED);
@@ -177,7 +176,7 @@ void GUILayer::onRender()
 void GUILayer::drawCheckboxWindow()
 {
     GUI::Window window{"Windows Checkbox"};
-    GUI::WidgetNodeGuard node{&window};
+    GUI::WidgetNode node{&window};
 
     for (auto& gui_window : m_gui_windows) {
         if (node.call<GUI::Checkbox>(gui_window->name(), gui_window->isOpenFlag());

--- a/examples/sandbox/gui_layer/gui_layer.cpp
+++ b/examples/sandbox/gui_layer/gui_layer.cpp
@@ -68,11 +68,13 @@ void drawProjectionCombo(GE::GUI::WidgetNodeGuard* node,
         GE::toString(GE::Scene::ViewProjectionCamera::PERSPECTIVE),
     };
 
-    GE::GUI::ComboBox combo{"Projection type", PROJECTIONS, GE::toString(camera->type())};
-    combo.itemChangedSignal()->connect([&camera](std::string_view projection) {
-        camera->setType(GE::Scene::toProjectionType(projection));
-    });
+    auto current_projection = GE::toString(camera->type());
+    GE::GUI::ComboBox combo{"Projection type", PROJECTIONS, current_projection};
     node->subNode(&combo);
+
+    if (combo.selectedItem() != current_projection) {
+        camera->setType(GE::Scene::toProjectionType(combo.selectedItem()));
+    }
 }
 
 void drawPerspectiveProjection(GE::GUI::WidgetNodeGuard* node,

--- a/examples/sandbox/gui_layer/gui_layer.h
+++ b/examples/sandbox/gui_layer/gui_layer.h
@@ -35,7 +35,7 @@
 #include <genesis/core/memory.h>
 #include <genesis/graphics/mesh.h>
 #include <genesis/gui/base_layer.h>
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 #include <genesis/gui/widgets/widget_node_guard.h>
 
 namespace GE::Examples {

--- a/examples/sandbox/gui_layer/gui_layer.h
+++ b/examples/sandbox/gui_layer/gui_layer.h
@@ -36,7 +36,7 @@
 #include <genesis/graphics/mesh.h>
 #include <genesis/gui/base_layer.h>
 #include <genesis/gui/widgets/widget.h>
-#include <genesis/gui/widgets/widget_node_guard.h>
+#include <genesis/gui/widgets/widget_node.h>
 
 namespace GE::Examples {
 

--- a/examples/sandbox/gui_layer/gui_layer_window.cpp
+++ b/examples/sandbox/gui_layer/gui_layer_window.cpp
@@ -64,7 +64,7 @@ void GuiLayerWindow::draw()
     }
 
     GUI::StyleVar padding{GUI::StyleVar::WINDOW_PADDING, {0.0f, 0.0f}};
-    GUI::WidgetNodeGuard node{&m_window};
+    GUI::WidgetNode node{&m_window};
     node.call(&GuiLayerWindow::updateWindowParameters, this);
 
     Drawable::mvp_t mvp{};

--- a/examples/sandbox/gui_layer/gui_layer_window.cpp
+++ b/examples/sandbox/gui_layer/gui_layer_window.cpp
@@ -65,6 +65,7 @@ void GuiLayerWindow::draw()
 
     GUI::StyleVar padding{GUI::StyleVar::WINDOW_PADDING, {0.0f, 0.0f}};
     GUI::WidgetNodeGuard node{&m_window};
+    node.call(&GuiLayerWindow::updateWindowParameters, this);
 
     Drawable::mvp_t mvp{};
     mvp.model = translate(Mat4{1.0f}, m_camera->position());
@@ -94,14 +95,16 @@ GuiLayerWindow::GuiLayerWindow(std::string name)
     GE_ASSERT(m_fbo, "Failed to create framebuffer");
 
     m_camera_controller->setViewport(model_fbo_config.size);
+}
 
-    m_window.isFocusedSignal()->connect([this](bool is_focused) { m_is_focused = is_focused; });
-    m_window.availableRegionSignal()->connect([this](const Vec2& size) {
-        if (m_fbo->size() != size) {
-            m_fbo->resize(size);
-            m_camera_controller->setViewport(size);
-        }
-    });
+void GuiLayerWindow::updateWindowParameters()
+{
+    m_is_focused = m_window.isFocused();
+
+    if (auto viewport = m_window.availableRegion(); viewport != m_fbo->size()) {
+        m_fbo->resize(viewport);
+        m_camera_controller->setViewport(viewport);
+    }
 }
 
 } // namespace GE::Examples

--- a/examples/sandbox/gui_layer/gui_layer_window.h
+++ b/examples/sandbox/gui_layer/gui_layer_window.h
@@ -70,6 +70,8 @@ public:
 private:
     explicit GuiLayerWindow(std::string name);
 
+    void updateWindowParameters();
+
     bool m_is_open{false};
     bool m_is_focused{false};
     std::string m_name;

--- a/include/genesis/core/memory.h
+++ b/include/genesis/core/memory.h
@@ -39,8 +39,8 @@
 
 namespace GE {
 
-template<typename T>
-using Scoped = std::unique_ptr<T>;
+template<typename T, typename D = std::default_delete<T>>
+using Scoped = std::unique_ptr<T, D>;
 
 template<typename T>
 using Shared = std::shared_ptr<T>;

--- a/include/genesis/gui/gizmos/gizmos.h
+++ b/include/genesis/gui/gizmos/gizmos.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 #include <genesis/math/types.h>
 
 namespace GE::GUI {

--- a/include/genesis/gui/widgets.h
+++ b/include/genesis/gui/widgets.h
@@ -51,5 +51,5 @@
 #include <genesis/gui/widgets/tree_node.h>
 #include <genesis/gui/widgets/value_editor.h>
 #include <genesis/gui/widgets/widget.h>
-#include <genesis/gui/widgets/widget_node_guard.h>
+#include <genesis/gui/widgets/widget_node.h>
 #include <genesis/gui/widgets/window.h>

--- a/include/genesis/gui/widgets.h
+++ b/include/genesis/gui/widgets.h
@@ -50,6 +50,6 @@
 #include <genesis/gui/widgets/text.h>
 #include <genesis/gui/widgets/tree_node.h>
 #include <genesis/gui/widgets/value_editor.h>
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 #include <genesis/gui/widgets/widget_node_guard.h>
 #include <genesis/gui/widgets/window.h>

--- a/include/genesis/gui/widgets/combo_box.h
+++ b/include/genesis/gui/widgets/combo_box.h
@@ -33,13 +33,13 @@
 #pragma once
 
 #include <genesis/core/bit.h>
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 
 #include <string_view>
 
 namespace GE::GUI {
 
-class GE_API ComboBox: public WidgetNode
+class GE_API ComboBox: public Widget
 {
 public:
     using Flags = int;

--- a/include/genesis/gui/widgets/combo_box.h
+++ b/include/genesis/gui/widgets/combo_box.h
@@ -35,9 +35,7 @@
 #include <genesis/core/bit.h>
 #include <genesis/gui/widgets/widget_node.h>
 
-#include <boost/signals2/signal.hpp>
-
-#include <string>
+#include <string_view>
 
 namespace GE::GUI {
 
@@ -46,7 +44,6 @@ class GE_API ComboBox: public WidgetNode
 public:
     using Flags = int;
     using Items = std::vector<std::string_view>;
-    using ItemChangedSignal = boost::signals2::signal<void(std::string_view)>;
 
     enum Flag
     {
@@ -69,18 +66,12 @@ public:
 
     ComboBox(std::string_view name, Items items, std::string_view current_item, Flags flags = NONE);
 
-    void emitSignals() override;
-
     std::string_view selectedItem() const { return m_selected_item; }
-
-    ItemChangedSignal* itemChangedSignal() { return &m_item_changed; }
 
 private:
     Items m_items;
     std::string_view m_current_item;
     std::string_view m_selected_item;
-
-    ItemChangedSignal m_item_changed;
 };
 
 } // namespace GE::GUI

--- a/include/genesis/gui/widgets/main_menu_bar.h
+++ b/include/genesis/gui/widgets/main_menu_bar.h
@@ -32,11 +32,11 @@
 
 #pragma once
 
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 
 namespace GE::GUI {
 
-class GE_API MainMenuBar: public WidgetNode
+class GE_API MainMenuBar: public Widget
 {
 public:
     MainMenuBar();

--- a/include/genesis/gui/widgets/menu.h
+++ b/include/genesis/gui/widgets/menu.h
@@ -32,13 +32,13 @@
 
 #pragma once
 
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 
 #include <string_view>
 
 namespace GE::GUI {
 
-class GE_API Menu: public WidgetNode
+class GE_API Menu: public Widget
 {
 public:
     explicit Menu(std::string_view label, bool enabled = true);

--- a/include/genesis/gui/widgets/popup_context_item.h
+++ b/include/genesis/gui/widgets/popup_context_item.h
@@ -34,13 +34,13 @@
 
 #include <genesis/core/export.h>
 #include <genesis/gui/widgets/flags.h>
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 
 #include <string_view>
 
 namespace GE::GUI {
 
-class GE_API PopupContextItem: public WidgetNode
+class GE_API PopupContextItem: public Widget
 {
 public:
     explicit PopupContextItem(std::string_view str_id = {},

--- a/include/genesis/gui/widgets/popup_context_window.h
+++ b/include/genesis/gui/widgets/popup_context_window.h
@@ -33,13 +33,13 @@
 #pragma once
 
 #include <genesis/gui/widgets/flags.h>
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 
 #include <string_view>
 
 namespace GE::GUI {
 
-class GE_API PopupContextWindow: public WidgetNode
+class GE_API PopupContextWindow: public Widget
 {
 public:
     explicit PopupContextWindow(std::string_view str_id = {},

--- a/include/genesis/gui/widgets/tree_node.h
+++ b/include/genesis/gui/widgets/tree_node.h
@@ -33,13 +33,13 @@
 #pragma once
 
 #include <genesis/core/bit.h>
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 
 #include <string_view>
 
 namespace GE::GUI {
 
-class GE_API TreeNode: public WidgetNode
+class GE_API TreeNode: public Widget
 {
 public:
     enum Flag : int

--- a/include/genesis/gui/widgets/widget.h
+++ b/include/genesis/gui/widgets/widget.h
@@ -38,7 +38,7 @@
 
 namespace GE::GUI {
 
-class GE_API WidgetNode: public Interface
+class GE_API Widget: public Interface
 {
 public:
     void begin()

--- a/include/genesis/gui/widgets/widget_node.h
+++ b/include/genesis/gui/widgets/widget_node.h
@@ -37,23 +37,23 @@
 
 namespace GE::GUI {
 
-class GE_API WidgetNodeGuard
+class GE_API WidgetNode
 {
 public:
-    explicit WidgetNodeGuard(Widget* widget)
+    explicit WidgetNode(Widget* widget)
         : m_widget{widget}
     {
         begin();
     }
 
-    explicit WidgetNodeGuard(Scoped<Widget> widget)
+    explicit WidgetNode(Scoped<Widget> widget)
         : m_internal_widget{std::move(widget)}
         , m_widget{m_internal_widget.get()}
     {
         begin();
     }
 
-    ~WidgetNodeGuard()
+    ~WidgetNode()
     {
         if (m_widget != nullptr) {
             m_widget->end();
@@ -87,32 +87,32 @@ public:
         }
     }
 
-    WidgetNodeGuard subNode(Widget* widget_node)
+    WidgetNode subNode(Widget* widget_node)
     {
         if (isOpened()) {
-            return WidgetNodeGuard{widget_node};
+            return WidgetNode{widget_node};
         }
 
-        return WidgetNodeGuard{nullptr};
+        return WidgetNode{nullptr};
     }
 
     template<typename T, typename... Args>
-    WidgetNodeGuard makeSubNode(Args&&... args)
+    WidgetNode makeSubNode(Args&&... args)
     {
         if (isOpened()) {
             return create<T>(std::forward<Args>(args)...);
         }
 
-        return WidgetNodeGuard{nullptr};
+        return WidgetNode{nullptr};
     }
 
     Widget* widget() { return m_widget; }
     bool isOpened() const { return m_widget != nullptr && m_widget->isOpened(); }
 
     template<typename T, typename... Args>
-    static WidgetNodeGuard create(Args&&... args)
+    static WidgetNode create(Args&&... args)
     {
-        return WidgetNodeGuard{makeScoped<T>(std::forward<Args>(args)...)};
+        return WidgetNode{makeScoped<T>(std::forward<Args>(args)...)};
     }
 
 private:

--- a/include/genesis/gui/widgets/widget_node.h
+++ b/include/genesis/gui/widgets/widget_node.h
@@ -87,7 +87,7 @@ public:
         }
     }
 
-    WidgetNode subNode(Widget* widget_node)
+    WidgetNode subNode(Widget* widget_node) const
     {
         if (isOpened()) {
             return WidgetNode{widget_node};

--- a/include/genesis/gui/widgets/widget_node.h
+++ b/include/genesis/gui/widgets/widget_node.h
@@ -57,8 +57,6 @@ public:
 
     bool isOpened() const { return m_is_opened; }
 
-    virtual void emitSignals() {}
-
 protected:
     using BeginFunc = std::function<bool()>;
     using EndFunc = std::function<void()>;

--- a/include/genesis/gui/widgets/widget_node_guard.h
+++ b/include/genesis/gui/widgets/widget_node_guard.h
@@ -33,20 +33,20 @@
 #pragma once
 
 #include <genesis/core/memory.h>
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 
 namespace GE::GUI {
 
 class GE_API WidgetNodeGuard
 {
 public:
-    explicit WidgetNodeGuard(WidgetNode* widget)
+    explicit WidgetNodeGuard(Widget* widget)
         : m_widget{widget}
     {
         begin();
     }
 
-    explicit WidgetNodeGuard(Scoped<WidgetNode> widget)
+    explicit WidgetNodeGuard(Scoped<Widget> widget)
         : m_internal_widget{std::move(widget)}
         , m_widget{m_internal_widget.get()}
     {
@@ -87,7 +87,7 @@ public:
         }
     }
 
-    WidgetNodeGuard subNode(WidgetNode* widget_node)
+    WidgetNodeGuard subNode(Widget* widget_node)
     {
         if (isOpened()) {
             return WidgetNodeGuard{widget_node};
@@ -106,7 +106,7 @@ public:
         return WidgetNodeGuard{nullptr};
     }
 
-    WidgetNode* widget() { return m_widget; }
+    Widget* widget() { return m_widget; }
     bool isOpened() const { return m_widget != nullptr && m_widget->isOpened(); }
 
     template<typename T, typename... Args>
@@ -123,8 +123,8 @@ private:
         }
     }
 
-    Scoped<WidgetNode> m_internal_widget;
-    WidgetNode* m_widget{nullptr};
+    Scoped<Widget> m_internal_widget;
+    Widget* m_widget{nullptr};
 };
 
 } // namespace GE::GUI

--- a/include/genesis/gui/widgets/widget_node_guard.h
+++ b/include/genesis/gui/widgets/widget_node_guard.h
@@ -120,7 +120,6 @@ private:
     {
         if (m_widget != nullptr) {
             m_widget->begin();
-            m_widget->emitSignals();
         }
     }
 

--- a/include/genesis/gui/widgets/window.h
+++ b/include/genesis/gui/widgets/window.h
@@ -32,14 +32,14 @@
 
 #pragma once
 
-#include <genesis/gui/widgets/widget_node.h>
+#include <genesis/gui/widgets/widget.h>
 #include <genesis/math/types.h>
 
 #include <string_view>
 
 namespace GE::GUI {
 
-class GE_API Window: public WidgetNode
+class GE_API Window: public Widget
 {
 public:
     using Flags = int;

--- a/include/genesis/gui/widgets/window.h
+++ b/include/genesis/gui/widgets/window.h
@@ -35,8 +35,6 @@
 #include <genesis/gui/widgets/widget_node.h>
 #include <genesis/math/types.h>
 
-#include <boost/signals2/signal.hpp>
-
 #include <string_view>
 
 namespace GE::GUI {
@@ -46,14 +44,7 @@ class GE_API Window: public WidgetNode
 public:
     using Flags = int;
 
-    using SizeSignal = boost::signals2::signal<void(const Vec2&)>;
-    using AvailableRegionSignal = boost::signals2::signal<void(const Vec2&)>;
-    using IsFocusedSignal = boost::signals2::signal<void(bool)>;
-    using IsHoveredSignal = boost::signals2::signal<void(bool)>;
-
     explicit Window(std::string_view title, bool* is_open = nullptr, Flags flags = 0);
-
-    void emitSignals() override;
 
     Vec2 position() const;
     Vec2 mousePosition() const;
@@ -63,17 +54,6 @@ public:
 
     bool isFocused() const;
     bool isHovered() const;
-
-    SizeSignal* sizeSignal() { return &m_size_signal; }
-    AvailableRegionSignal* availableRegionSignal() { return &m_available_region_signal; }
-    IsFocusedSignal* isFocusedSignal() { return &m_is_focused_signal; }
-    IsHoveredSignal* isHoveredSignal() { return &m_is_hovered_signal; }
-
-private:
-    SizeSignal m_size_signal;
-    AvailableRegionSignal m_available_region_signal;
-    IsFocusedSignal m_is_focused_signal;
-    IsHoveredSignal m_is_hovered_signal;
 };
 
 } // namespace GE::GUI

--- a/include/genesis/gui/window/imenu.h
+++ b/include/genesis/gui/window/imenu.h
@@ -41,14 +41,14 @@ class Event;
 
 namespace GE::GUI {
 
-class WidgetNodeGuard;
+class WidgetNode;
 
 class GE_API IMenu: public Interface
 {
 public:
     virtual void onUpdate(Timestamp ts) = 0;
     virtual void onEvent(Event* event) = 0;
-    virtual void onRender(WidgetNodeGuard* bar_node) = 0;
+    virtual void onRender(WidgetNode* bar_node) = 0;
 };
 
 } // namespace GE::GUI

--- a/include/genesis/gui/window/menu_list.h
+++ b/include/genesis/gui/window/menu_list.h
@@ -44,7 +44,7 @@ class GE_API MenuList: public IMenu
 public:
     void onUpdate(Timestamp ts) override;
     void onEvent(Event* event) override;
-    void onRender(WidgetNodeGuard* node) override;
+    void onRender(WidgetNode* node) override;
 
     void appendMenu(Shared<IMenu> menu);
 

--- a/src/genesis/gui/CMakeLists.txt
+++ b/src/genesis/gui/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND GUI_HEADERS
     ${INCLUDE_DIR}/widgets/tree_node.h
     ${INCLUDE_DIR}/widgets/value_editor.h
     ${INCLUDE_DIR}/widgets/widget.h
-    ${INCLUDE_DIR}/widgets/widget_node_guard.h
+    ${INCLUDE_DIR}/widgets/widget_node.h
     ${INCLUDE_DIR}/widgets/window.h
     ${INCLUDE_DIR}/window/imenu.h
     ${INCLUDE_DIR}/window/iwindow.h

--- a/src/genesis/gui/CMakeLists.txt
+++ b/src/genesis/gui/CMakeLists.txt
@@ -58,7 +58,7 @@ list(APPEND GUI_HEADERS
     ${INCLUDE_DIR}/widgets/text.h
     ${INCLUDE_DIR}/widgets/tree_node.h
     ${INCLUDE_DIR}/widgets/value_editor.h
-    ${INCLUDE_DIR}/widgets/widget_node.h
+    ${INCLUDE_DIR}/widgets/widget.h
     ${INCLUDE_DIR}/widgets/widget_node_guard.h
     ${INCLUDE_DIR}/widgets/window.h
     ${INCLUDE_DIR}/window/imenu.h

--- a/src/genesis/gui/widgets/combo_box.cpp
+++ b/src/genesis/gui/widgets/combo_box.cpp
@@ -72,11 +72,4 @@ ComboBox::ComboBox(std::string_view name, Items items, std::string_view current_
     setEndFunc(&ImGui::EndCombo);
 }
 
-void ComboBox::emitSignals()
-{
-    if (m_selected_item != m_current_item) {
-        m_item_changed(m_selected_item);
-    }
-}
-
 } // namespace GE::GUI

--- a/src/genesis/gui/widgets/window.cpp
+++ b/src/genesis/gui/widgets/window.cpp
@@ -96,12 +96,4 @@ bool Window::isHovered() const
     return ImGui::IsWindowHovered();
 }
 
-void Window::emitSignals()
-{
-    m_size_signal(size());
-    m_available_region_signal(availableRegion());
-    m_is_focused_signal(isFocused());
-    m_is_hovered_signal(isHovered());
-}
-
 } // namespace GE::GUI

--- a/src/genesis/gui/window/menu_list.cpp
+++ b/src/genesis/gui/window/menu_list.cpp
@@ -48,7 +48,7 @@ void MenuList::onEvent(Event* event)
     }
 }
 
-void MenuList::onRender(WidgetNodeGuard* node)
+void MenuList::onRender(WidgetNode* node)
 {
     for (auto& menu : m_menus) {
         menu->onRender(node);


### PR DESCRIPTION
- Renamed `WidgetNode` and `WidgetNodeGuard`
- Removed emission of signals from GUI widgets
- Added support for the creation a widget node directly as a subnode