### PR TITLE
Fix scene's children deserialization

### DIFF
--- a/include/genesis/scene/components/yaml_convert.h
+++ b/include/genesis/scene/components/yaml_convert.h
@@ -45,7 +45,7 @@ namespace YAML {
 template<>
 struct convert<GE::Scene::CameraComponent> {
     using Component = GE::Scene::CameraComponent;
-    static constexpr auto TYPE{Component ::NAME};
+    static constexpr auto TYPE{Component::NAME};
 
     static bool decode(const Node& node, Component& camera)
     {

--- a/include/genesis/scene/entity_node.h
+++ b/include/genesis/scene/entity_node.h
@@ -45,8 +45,8 @@ public:
     EntityNode() = default;
     explicit EntityNode(const Entity& entity);
 
-    EntityNode& insert(const Entity& entity);
-    EntityNode& appendChild(const Entity& child_entity);
+    EntityNode insert(const Entity& entity);
+    EntityNode appendChild(const Entity& child_entity);
 
     EntityNode prevNode() const;
     EntityNode nextNode() const;

--- a/src/genesis/filesystem/tmp_dir_guard.cpp
+++ b/src/genesis/filesystem/tmp_dir_guard.cpp
@@ -43,7 +43,8 @@ namespace {
 
 std::string tmpDirPath()
 {
-    return boost::filesystem::unique_path().string();
+    using namespace boost::filesystem;
+    return (temp_directory_path() / unique_path()).string();
 }
 
 } // namespace

--- a/src/genesis/scene/entity_node.cpp
+++ b/src/genesis/scene/entity_node.cpp
@@ -60,7 +60,7 @@ EntityNode::EntityNode(const Entity& entity)
     : m_entity{entity}
 {}
 
-EntityNode& EntityNode::insert(const Entity& entity)
+EntityNode EntityNode::insert(const Entity& entity)
 {
     GE_CORE_ASSERT(!isNull(), "Entity cannot be Null");
     GE_CORE_ASSERT(m_entity != entity, "Cannot append entity to itself");
@@ -78,11 +78,10 @@ EntityNode& EntityNode::insert(const Entity& entity)
 
     node().next_node = entity.nativeHandle();
     moveTailToNextNode();
-
-    return *this;
+    return inserted_entity;
 }
 
-EntityNode& EntityNode::appendChild(const Entity& child_entity)
+EntityNode EntityNode::appendChild(const Entity& child_entity)
 {
     GE_CORE_ASSERT(!isNull(), "Parent entity cannot be Null");
     GE_CORE_ASSERT(!child_entity.isNull(), "Child entity cannot be Null");
@@ -97,7 +96,7 @@ EntityNode& EntityNode::appendChild(const Entity& child_entity)
     child_node.eject();
     child_node.node().parent_node = m_entity.nativeHandle();
     node().child_node = child_entity.nativeHandle();
-    return *this;
+    return child_node;
 }
 
 EntityNode EntityNode::prevNode() const

--- a/src/genesis/scene/scene_deserializer.cpp
+++ b/src/genesis/scene/scene_deserializer.cpp
@@ -87,11 +87,6 @@ Entity SceneDeserializer::loadEntities(Scene *scene, const YAML::Node &node)
 
     for (uint32_t i{1}; i < node.size(); i++) {
         auto entity = loadEntity(scene, node[i]);
-
-        if (auto children_node = node[i]["children"]; children_node.IsDefined()) {
-            EntityNode{entity}.appendChild(loadEntities(scene, children_node));
-        }
-
         EntityNode{last_entity}.insert(entity);
         last_entity = entity;
     }
@@ -99,6 +94,7 @@ Entity SceneDeserializer::loadEntities(Scene *scene, const YAML::Node &node)
     return first_entity;
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 Entity SceneDeserializer::loadEntity(Scene *scene, const YAML::Node &node)
 {
     auto entity = scene->createEntity();
@@ -107,6 +103,10 @@ Entity SceneDeserializer::loadEntity(Scene *scene, const YAML::Node &node)
         if (!loadComponent(&entity, component_node)) {
             GE_CORE_ERR("Failed to load components for an entity");
         }
+    }
+
+    if (auto children_node = node["children"]; children_node.IsDefined()) {
+        EntityNode{entity}.appendChild(loadEntities(scene, children_node));
     }
 
     return entity;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(GoogleTest)
+
 add_subdirectory(core)
 add_subdirectory(graphics)
 add_subdirectory(window)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,4 +2,5 @@ include(GoogleTest)
 
 add_subdirectory(core)
 add_subdirectory(graphics)
+add_subdirectory(scene)
 add_subdirectory(window)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,9 +1,11 @@
 list(APPEND GE_CORE_TEST_SRC
-    timestamp_test.cpp)
+    timestamp_test.cpp
+    )
 
 add_executable(genesis_core_test ${GE_CORE_TEST_SRC})
 target_link_libraries(genesis_core_test PRIVATE
     genesis::core
-    gtest_main)
+    gtest_main
+    )
 
-add_test(NAME genesis_core_test COMMAND genesis_core_test)
+gtest_discover_tests(genesis_core_test)

--- a/tests/graphics/CMakeLists.txt
+++ b/tests/graphics/CMakeLists.txt
@@ -1,11 +1,13 @@
 list(APPEND GE_GRAPHICS_TEST_SRC
-    shader_reflection_test.cpp)
+    shader_reflection_test.cpp
+    )
 
 add_executable(genesis_graphics_test ${GE_GRAPHICS_TEST_SRC})
 target_link_libraries(genesis_graphics_test PRIVATE
     genesis::graphics
-    gtest_main)
+    gtest_main
+    )
 
-add_test(NAME genesis_graphics_test
-    COMMAND genesis_graphics_test
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+gtest_discover_tests(genesis_graphics_test
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )

--- a/tests/scene/CMakeLists.txt
+++ b/tests/scene/CMakeLists.txt
@@ -1,0 +1,19 @@
+list(APPEND GE_SCENE_TEST_SRC
+    scene_deserializer_test.cpp
+    scene_serializer_test.cpp
+    )
+
+list(APPEND GE_SCENE_TEST_HEADERS
+    component_matchers.h
+    )
+
+add_executable(genesis_scene_test ${GE_SCENE_TEST_SRC} ${GE_SCENE_TEST_HEADERS})
+target_include_directories(genesis_scene_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(genesis_scene_test PRIVATE
+    genesis::filesystem
+    genesis::scene
+    gmock
+    gtest_main
+    )
+
+gtest_discover_tests(genesis_scene_test)

--- a/tests/scene/component_matchers.h
+++ b/tests/scene/component_matchers.h
@@ -1,0 +1,55 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Dmitry Shilnenkov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+namespace GE::Tests {
+
+using testing::DescribeMatcher;
+
+MATCHER_P(isTagComponent, tag,
+          std::string{negation ? "isn't" : "is"} + " a 'Tag' component whose tag " +
+              DescribeMatcher<std::string>(tag))
+{
+    using testing::ExplainMatchResult;
+
+    if (!ExplainMatchResult(tag, arg.tag, result_listener)) {
+        *result_listener << "actual tag: '" << arg.tag << "'";
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace GE::Tests

--- a/tests/scene/scene_deserializer_test.cpp
+++ b/tests/scene/scene_deserializer_test.cpp
@@ -1,0 +1,266 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Dmitry Shilnenkov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "component_matchers.h"
+
+#include "genesis/assets/registry.h"
+#include "genesis/filesystem/file.h"
+#include "genesis/filesystem/filepath.h"
+#include "genesis/filesystem/tmp_dir_guard.h"
+#include "genesis/scene/components.h"
+#include "genesis/scene/entity_node.h"
+#include "genesis/scene/scene.h"
+#include "genesis/scene/scene_deserializer.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <string>
+
+using namespace GE::Scene;
+using namespace GE::Tests;
+using namespace testing;
+
+namespace {
+
+void writeToFile(std::string_view filename, std::string_view content)
+{
+    std::ofstream file{filename.data()};
+    ASSERT_TRUE(file);
+    file << content;
+}
+
+class SceneDeserializerTest: public Test
+{
+protected:
+    static void SetUpTestCase()
+    {
+        GE::Log::initialize({GE::Logger::Level::ERROR, GE::Logger::Level::ERROR});
+    }
+
+    std::string tmpSceneFilepath() const { return GE::FS::joinPath(tmpDir.path(), "scene.yaml"); }
+
+    GE::FS::TmpDirGuard tmpDir;
+    Scene scene;
+    GE::Assets::Registry assets;
+    SceneDeserializer deserializer{&scene, &assets};
+};
+
+TEST_F(SceneDeserializerTest, MultipleLevelsOfEntitiesGoFirst)
+{
+    constexpr std::string_view SCENE_FILE = R"(
+scene:
+  name: "TestScene"
+  serialization_version: 1
+  entities:
+    - components:
+        - type: Tag
+          tag: "parent 1"
+      children:
+        - components:
+            - type: Tag
+              tag: "child 1-1"
+          children:
+            - components:
+                - type: Tag
+                  tag: "child 1-2"
+    - components:
+        - type: Tag
+          tag: "parent 2"
+)";
+
+    auto scene_filepath = tmpSceneFilepath();
+    writeToFile(scene_filepath, SCENE_FILE);
+
+    ASSERT_TRUE(deserializer.deserialize(scene_filepath));
+
+    auto parent1 = EntityNode{scene.headEntity()};
+    ASSERT_FALSE(parent1.isNull());
+    EXPECT_THAT(parent1.entity().get<TagComponent>(), isTagComponent("parent 1"));
+    EXPECT_TRUE(parent1.hasNextNode());
+    ASSERT_TRUE(parent1.hasChildNode());
+
+    auto child1 = parent1.childNode();
+    ASSERT_FALSE(child1.isNull());
+    EXPECT_THAT(child1.entity().get<TagComponent>(), isTagComponent("child 1-1"));
+    EXPECT_FALSE(child1.hasNextNode());
+    ASSERT_TRUE(child1.hasChildNode());
+
+    auto child2 = child1.childNode();
+    ASSERT_FALSE(child2.isNull());
+    EXPECT_THAT(child2.entity().get<TagComponent>(), isTagComponent("child 1-2"));
+    EXPECT_FALSE(child2.hasNextNode());
+    EXPECT_FALSE(child2.hasChildNode());
+
+    auto parent2 = parent1.nextNode();
+    ASSERT_FALSE(parent2.isNull());
+    EXPECT_THAT(parent2.entity().get<TagComponent>(), isTagComponent("parent 2"));
+    EXPECT_FALSE(parent2.hasNextNode());
+    EXPECT_FALSE(parent2.hasChildNode());
+}
+
+TEST_F(SceneDeserializerTest, MultipleLevelsOfEntitiesInTheMiddle)
+{
+    constexpr std::string_view SCENE_FILE = R"(
+scene:
+  name: "TestScene"
+  serialization_version: 1
+  entities:
+    - components:
+        - type: Tag
+          tag: "parent 1"
+    - components:
+        - type: Tag
+          tag: "parent 2"
+      children:
+        - components:
+            - type: Tag
+              tag: "child 2-1"
+          children:
+            - components:
+                - type: Tag
+                  tag: "child 2-2"
+    - components:
+        - type: Tag
+          tag: "parent 3"
+)";
+
+    auto scene_filepath = tmpSceneFilepath();
+    writeToFile(scene_filepath, SCENE_FILE);
+
+    ASSERT_TRUE(deserializer.deserialize(scene_filepath));
+
+    auto parent1 = EntityNode{scene.headEntity()};
+    ASSERT_FALSE(parent1.isNull());
+    EXPECT_THAT(parent1.entity().get<TagComponent>(), isTagComponent("parent 1"));
+    EXPECT_TRUE(parent1.hasNextNode());
+    EXPECT_FALSE(parent1.hasChildNode());
+
+    auto parent2 = parent1.nextNode();
+    ASSERT_FALSE(parent2.isNull());
+    EXPECT_THAT(parent2.entity().get<TagComponent>(), isTagComponent("parent 2"));
+    EXPECT_TRUE(parent2.hasNextNode());
+    ASSERT_TRUE(parent2.hasChildNode());
+
+    auto child1 = parent2.childNode();
+    ASSERT_FALSE(child1.isNull());
+    EXPECT_THAT(child1.entity().get<TagComponent>(), isTagComponent("child 2-1"));
+    EXPECT_FALSE(child1.hasNextNode());
+    ASSERT_TRUE(child1.hasChildNode());
+
+    auto child2 = child1.childNode();
+    ASSERT_FALSE(child2.isNull());
+    EXPECT_THAT(child2.entity().get<TagComponent>(), isTagComponent("child 2-2"));
+    EXPECT_FALSE(child2.hasNextNode());
+    EXPECT_FALSE(child2.hasChildNode());
+
+    auto parent3 = parent2.nextNode();
+    ASSERT_FALSE(parent3.isNull());
+    EXPECT_THAT(parent3.entity().get<TagComponent>(), isTagComponent("parent 3"));
+    EXPECT_FALSE(parent3.hasNextNode());
+    EXPECT_FALSE(parent3.hasChildNode());
+}
+
+TEST_F(SceneDeserializerTest, MultipleLevelsOfEntitiesGoLast)
+{
+    constexpr std::string_view SCENE_FILE = R"(
+scene:
+  name: "TestScene"
+  serialization_version: 1
+  entities:
+    - components:
+        - type: Tag
+          tag: "parent 1"
+    - components:
+        - type: Tag
+          tag: "parent 2"
+      children:
+        - components:
+            - type: Tag
+              tag: "child 2-1"
+          children:
+            - components:
+                - type: Tag
+                  tag: "child 2-2"
+)";
+
+    auto scene_filepath = tmpSceneFilepath();
+    writeToFile(scene_filepath, SCENE_FILE);
+
+    ASSERT_TRUE(deserializer.deserialize(scene_filepath));
+
+    auto parent1 = EntityNode{scene.headEntity()};
+    ASSERT_FALSE(parent1.isNull());
+    EXPECT_THAT(parent1.entity().get<TagComponent>(), isTagComponent("parent 1"));
+    EXPECT_TRUE(parent1.hasNextNode());
+    EXPECT_FALSE(parent1.hasChildNode());
+
+    auto parent2 = parent1.nextNode();
+    ASSERT_FALSE(parent2.isNull());
+    EXPECT_THAT(parent2.entity().get<TagComponent>(), isTagComponent("parent 2"));
+    EXPECT_FALSE(parent2.hasNextNode());
+    ASSERT_TRUE(parent2.hasChildNode());
+
+    auto child1 = parent2.childNode();
+    ASSERT_FALSE(child1.isNull());
+    EXPECT_THAT(child1.entity().get<TagComponent>(), isTagComponent("child 2-1"));
+    EXPECT_FALSE(child1.hasNextNode());
+    ASSERT_TRUE(child1.hasChildNode());
+
+    auto child2 = child1.childNode();
+    ASSERT_FALSE(child2.isNull());
+    EXPECT_THAT(child2.entity().get<TagComponent>(), isTagComponent("child 2-2"));
+    EXPECT_FALSE(child2.hasNextNode());
+    EXPECT_FALSE(child2.hasChildNode());
+}
+
+TEST_F(SceneDeserializerTest, EmptyChildren)
+{
+    constexpr std::string_view SCENE_FILE = R"(
+scene:
+  name: "TestScene"
+  serialization_version: 1
+  entities:
+    - components:
+        - type: Tag
+          tag: "parent 1"
+      children:
+)";
+
+    auto scene_filepath = tmpSceneFilepath();
+    writeToFile(scene_filepath, SCENE_FILE);
+
+    ASSERT_FALSE(deserializer.deserialize(scene_filepath));
+}
+
+} // namespace

--- a/tests/scene/scene_serializer_test.cpp
+++ b/tests/scene/scene_serializer_test.cpp
@@ -1,0 +1,164 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2024, Dmitry Shilnenkov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "component_matchers.h"
+
+#include "genesis/filesystem/filepath.h"
+#include "genesis/filesystem/tmp_dir_guard.h"
+#include "genesis/scene/components/tag_component.h"
+#include "genesis/scene/components/yaml_convert.h"
+#include "genesis/scene/entity_node.h"
+#include "genesis/scene/scene.h"
+#include "genesis/scene/scene_serializer.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <yaml-cpp/node/parse.h>
+
+using namespace GE::Scene;
+using namespace GE::Tests;
+using namespace testing;
+
+namespace {
+
+class SceneSerializerTest: public Test
+{
+protected:
+    std::string tmpSceneFilepath() const { return GE::FS::joinPath(tmpDir.path(), "scene.yaml"); }
+
+    GE::FS::TmpDirGuard tmpDir;
+    Scene scene;
+    SceneSerializer serializer{&scene};
+};
+
+TEST_F(SceneSerializerTest, MultipleLevelsOfEntitiesGoFirst)
+{
+    {
+        EntityNode parent_node_1{scene.createEntity("parent 1")};
+        parent_node_1.insert(scene.createEntity("parent 2"));
+
+        auto child_node_1 = parent_node_1.appendChild(scene.createEntity("child 1-1"));
+        child_node_1.appendChild(scene.createEntity("child 1-2"));
+    }
+
+    auto scene_filepath = tmpSceneFilepath();
+    ASSERT_TRUE(serializer.serialize(scene_filepath));
+
+    // Parents
+
+    auto scene_yaml = YAML::LoadFile(scene_filepath)["scene"];
+    auto parent_yaml_1 = scene_yaml["entities"][0];
+    EXPECT_THAT(parent_yaml_1["components"][0].as<TagComponent>(), isTagComponent("parent 1"));
+
+    auto parent_yaml_2 = scene_yaml["entities"][1];
+    EXPECT_THAT(parent_yaml_2["components"][0].as<TagComponent>(), isTagComponent("parent 2"));
+
+    // Children of the 1st parent
+
+    auto child_yaml_1 = parent_yaml_1["children"][0];
+    EXPECT_THAT(child_yaml_1["components"][0].as<TagComponent>(), isTagComponent("child 1-1"));
+
+    auto child_yaml_2 = child_yaml_1["children"][0];
+    EXPECT_THAT(child_yaml_2["components"][0].as<TagComponent>(), isTagComponent("child 1-2"));
+}
+
+TEST_F(SceneSerializerTest, MultipleLevelsOfEntitiesInTheMiddle)
+{
+    {
+        EntityNode parent_node_1{scene.createEntity("parent 1")};
+        auto parent_node_2 = parent_node_1.insert(scene.createEntity("parent 2"));
+        parent_node_2.insert(scene.createEntity("parent 3"));
+
+        auto child_node_1 = parent_node_2.appendChild(scene.createEntity("child 2-1"));
+        child_node_1.appendChild(scene.createEntity("child 2-2"));
+    }
+
+    auto scene_filepath = tmpSceneFilepath();
+    ASSERT_TRUE(serializer.serialize(scene_filepath));
+
+    // Parents
+
+    auto scene_yaml = YAML::LoadFile(scene_filepath)["scene"];
+    auto parent_yaml_1 = scene_yaml["entities"][0];
+    EXPECT_THAT(parent_yaml_1["components"][0].as<TagComponent>(), isTagComponent("parent 1"));
+
+    auto parent_yaml_2 = scene_yaml["entities"][1];
+    EXPECT_THAT(parent_yaml_2["components"][0].as<TagComponent>(), isTagComponent("parent 2"));
+
+    auto parent_yaml_3 = scene_yaml["entities"][2];
+    EXPECT_THAT(parent_yaml_3["components"][0].as<TagComponent>(), isTagComponent("parent 3"));
+
+    // Children of the 2nd parent
+
+    auto child_yaml_1 = parent_yaml_2["children"][0];
+    EXPECT_THAT(child_yaml_1["components"][0].as<TagComponent>(), isTagComponent("child 2-1"));
+
+    auto child_yaml_2 = child_yaml_1["children"][0];
+    EXPECT_THAT(child_yaml_2["components"][0].as<TagComponent>(), isTagComponent("child 2-2"));
+}
+
+TEST_F(SceneSerializerTest, MultipleLevelsOfEntitiesGoLast)
+{
+    {
+        EntityNode parent_node_1{scene.createEntity("parent 1")};
+        auto parent_node_2 = parent_node_1.insert(scene.createEntity("parent 2"));
+        auto parent_node_3 = parent_node_2.insert(scene.createEntity("parent 3"));
+
+        auto child_node_1 = parent_node_3.appendChild(scene.createEntity("child 3-1"));
+        child_node_1.appendChild(scene.createEntity("child 3-2"));
+    }
+
+    auto scene_filepath = tmpSceneFilepath();
+    ASSERT_TRUE(serializer.serialize(scene_filepath));
+
+    // Parents
+
+    auto scene_yaml = YAML::LoadFile(scene_filepath)["scene"];
+    auto parent_yaml_1 = scene_yaml["entities"][0];
+    EXPECT_THAT(parent_yaml_1["components"][0].as<TagComponent>(), isTagComponent("parent 1"));
+
+    auto parent_yaml_2 = scene_yaml["entities"][1];
+    EXPECT_THAT(parent_yaml_2["components"][0].as<TagComponent>(), isTagComponent("parent 2"));
+
+    auto parent_yaml_3 = scene_yaml["entities"][2];
+    EXPECT_THAT(parent_yaml_3["components"][0].as<TagComponent>(), isTagComponent("parent 3"));
+
+    // Children of the 3rd parent
+
+    auto child_yaml_1 = parent_yaml_3["children"][0];
+    EXPECT_THAT(child_yaml_1["components"][0].as<TagComponent>(), isTagComponent("child 3-1"));
+
+    auto child_yaml_2 = child_yaml_1["children"][0];
+    EXPECT_THAT(child_yaml_2["components"][0].as<TagComponent>(), isTagComponent("child 3-2"));
+}
+
+} // namespace

--- a/tests/window/CMakeLists.txt
+++ b/tests/window/CMakeLists.txt
@@ -1,9 +1,11 @@
 list(APPEND GE_CORE_TEST_SRC
-    events_test.cpp)
+    events_test.cpp
+    )
 
 add_executable(genesis_window_test ${GE_CORE_TEST_SRC})
 target_link_libraries(genesis_window_test PRIVATE
     genesis::window
-    gtest_main)
+    gtest_main
+    )
 
-add_test(NAME genesis_window_test COMMAND genesis_window_test)
+gtest_discover_tests(genesis_window_test)


### PR DESCRIPTION
- Update `EntityNode` to return inserted/appended Node
- Add tests for `SceneSerializer`/`SceneDeserializer`
- Fix children deserialization
- Use  `gtest_discover_tests()` to add tests