### PR TITLE
Use prebuilt Vulcan SDK and boost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       - name: clang-format
         run: make clang-format
       - name: clang-tidy
+        if: github.event_name == 'pull_request'
         env:
           BUILD_TYPE: ${{ matrix.build-type }}
         run: make clang-tidy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 project(genesis VERSION 0.0.0 LANGUAGES C CXX)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
 endif ()
 
+# Configure custom find modules
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/find-modules")
+
 # CMake options
 option(GE_STATIC "Build static library" OFF)
 option(GE_DISABLE_ASSERTS "Disable asserts" OFF)
@@ -41,6 +44,11 @@ message(STATUS "Build tests: ${GE_BUILD_TESTS}")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Find required packages
+find_package(ge-shaderc_combined REQUIRED)
+find_package(ge-spirv-cross REQUIRED)
+find_package(Vulkan REQUIRED)
 
 # Subdirectories
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Find required packages
+find_package(Boost "1.82" COMPONENTS filesystem REQUIRED)
 find_package(ge-shaderc_combined REQUIRED)
 find_package(ge-spirv-cross REQUIRED)
 find_package(Vulkan REQUIRED)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:focal AS cmake-builder
 ARG CMAKE_VER="v3.22.1"
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get update && apt-get install -y --no-install-recommends \
         build-essential ca-certificates git libssl-dev
 
@@ -20,7 +20,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 COPY --from=cmake-builder /opt/cmake/ /usr/local/
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get update && apt-get install -y --no-install-recommends \
 # Essential build tools
         build-essential ca-certificates git pkg-config python3 \
@@ -33,7 +33,7 @@ RUN --mount=type=bind,source=./tools,dst=/tmp/tools \
 # Boost library builder
 FROM ubuntu:focal AS boost-builder
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get update && apt-get install -y --no-install-recommends \
         build-essential ca-certificates wget
 
@@ -55,7 +55,7 @@ COPY --from=vulkan-sdk-builder /opt/vulkan-sdk /opt/vulkan-sdk
 COPY --from=boost-builder /opt/boost /opt/boost
 
 # Instal essential packages
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get update && apt-get install -y --no-install-recommends \
         gpg-agent software-properties-common wget vim \
 # GCC
@@ -74,7 +74,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     && git config --add --system safe.directory "*"
 
 # SDL2 dependencies
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get update && apt-get install -y --no-install-recommends \
         libx11-dev libsamplerate-dev libasound2-dev libjack-dev libpulse-dev libsndio-dev \
         libxcursor-dev libxinerama-dev libxi-dev libxrandr-dev libxss-dev libxxf86vm-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,34 +2,62 @@
 FROM ubuntu:focal AS cmake-builder
 ARG CMAKE_VER="v3.22.1"
 
-# Install build tools
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && apt-get install -y --no-install-recommends \
         build-essential ca-certificates git libssl-dev
 
-# Build and install CMake
 RUN git clone --depth 1 --branch "${CMAKE_VER}" https://github.com/Kitware/CMake /tmp/cmake \
     && mkdir -p /tmp/cmake/build && cd /tmp/cmake/build \
     && ../bootstrap --parallel=$(nproc) --prefix=/opt/cmake \
     && make -j$(nproc) && make install \
     && rm -rf /tmp/cmake
 
+# Vulkan SDK builder
+FROM ubuntu:focal AS vulkan-sdk-builder
+ARG VULKAN_SDK_VER="1.3.268.0"
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+COPY --from=cmake-builder /opt/cmake/ /usr/local/
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get install -y --no-install-recommends \
+# Essential build tools
+        build-essential ca-certificates git pkg-config python3 \
+# Vulkan SDK dependencies
+        libx11-dev libxrandr-dev libwayland-dev xorg-dev
+
+RUN --mount=type=bind,source=./tools,dst=/tmp/tools \
+    bash /tmp/tools/install_vulkan_sdk_linux.sh "${VULKAN_SDK_VER}" "/opt/vulkan-sdk"
+
+# Boost library builder
+FROM ubuntu:focal AS boost-builder
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get install -y --no-install-recommends \
+        build-essential ca-certificates wget
+
+RUN --mount=type=bind,source=./tools,dst=/tmp/tools \
+    bash /tmp/tools/install_boost_linux.sh "/opt/boost"
+
 # Genesis image
 FROM ubuntu:focal AS genesis-image
 
 # Arguments
-ARG GCC_VER=11   \
+ARG GCC_VER=11 \
     CLANG_VER=19
 
 ENV DEBIAN_FRONTEND="noninteractive"
 
-# Install cmake
+# Install built tools
 COPY --from=cmake-builder /opt/cmake/ /usr/local/
+COPY --from=vulkan-sdk-builder /opt/vulkan-sdk /opt/vulkan-sdk
+COPY --from=boost-builder /opt/boost /opt/boost
 
 # Instal essential packages
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && apt-get install -y --no-install-recommends \
-        gpg-agent software-properties-common wget \
+        gpg-agent software-properties-common wget vim \
 # GCC
     && apt-add-repository ppa:ubuntu-toolchain-r/test \
 # Clang tools
@@ -52,12 +80,10 @@ RUN --mount=type=cache,target=/var/cache/apt \
         libxcursor-dev libxinerama-dev libxi-dev libxrandr-dev libxss-dev libxxf86vm-dev \
         libdbus-1-dev
 
-# Vulkan dependencies
-RUN --mount=type=cache,target=/var/cache/apt \
-    apt-get update && apt-get install -y --no-install-recommends \
-        libwayland-dev
-
 ENV CC="gcc-${GCC_VER}" \
     CXX="g++-${GCC_VER}" \
     CLANG_FORMAT_BIN="clang-format-${CLANG_VER}" \
-    RUN_CLANG_TIDY_BIN="run-clang-tidy-${CLANG_VER}"
+    RUN_CLANG_TIDY_BIN="run-clang-tidy-${CLANG_VER}" \
+    VULKAN_SDK="/opt/vulkan-sdk" \
+    PKG_CONFIG_PATH="/opt/vulkan-sdk/lib/pkgconfig" \
+    BOOST_ROOT="/opt/boost"

--- a/README.md
+++ b/README.md
@@ -7,16 +7,7 @@
 - [SDL](https://github.com/libsdl-org/SDL.git) ([zlib](https://github.com/libsdl-org/SDL/blob/main/LICENSE.txt))
 - [spdlog](https://github.com/gabime/spdlog) ([MIT](https://github.com/gabime/spdlog/blob/v1.x/README.md))
 - [glm](https://github.com/g-truc/glm) ([MIT](https://github.com/g-truc/glm/blob/master/copying.txt))
-- Vulkan SDK (sdk-1.3.236.0):
-  - [Vulkan-Headers](https://github.com/KhronosGroup/Vulkan-Headers) ([Apache 2.0](https://github.com/KhronosGroup/Vulkan-Headers/blob/main/LICENSE.txt))
-  - [Vulkan-Loader](https://github.com/KhronosGroup/Vulkan-Loader) ([Apache 2.0](https://github.com/KhronosGroup/Vulkan-Loader/blob/master/LICENSE.txt))
-  - [glslang](https://github.com/KhronosGroup/glslang) ([Multi-licensed](https://github.com/KhronosGroup/glslang/blob/master/LICENSE.txt))
-  - [SPIRV-Headers](https://github.com/KhronosGroup/SPIRV-Headers) ([MIT](https://github.com/KhronosGroup/SPIRV-Headers/blob/main/LICENSE))
-  - [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools) ([Apache 2.0](https://github.com/KhronosGroup/SPIRV-Tools/blob/main/LICENSE))
-  - [SPIRV-Cross](https://github.com/KhronosGroup/SPIRV-Cross) ([Apache 2.0](https://github.com/KhronosGroup/SPIRV-Cross/blob/main/LICENSE))
-  - [Vulkan-ValidationLayers](https://github.com/KhronosGroup/Vulkan-ValidationLayers) ([Apache 2.0](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/LICENSE.txt))
-  - [shaderc](https://github.com/google/shaderc) ([Apache 2.0](https://github.com/google/shaderc/blob/main/LICENSE))
-  - [MoltenVK](https://github.com/KhronosGroup/MoltenVK) ([Apache 2.0](https://github.com/KhronosGroup/MoltenVK/blob/main/LICENSE))
+- [Vulkan SDK](https://vulkan.lunarg.com/#new_tab)
 - [stb](https://github.com/nothings/stb) ([MIT](https://github.com/nothings/stb/blob/master/LICENSE))
 - [tinyobjloader](https://github.com/tinyobjloader/tinyobjloader) ([MIT](https://github.com/tinyobjloader/tinyobjloader/blob/release/CMakeLists.txt))
 - [magic_enum](https://github.com/Neargye/magic_enum) ([MIT](https://github.com/Neargye/magic_enum/blob/master/LICENSE))
@@ -31,6 +22,14 @@
 - [nativefiledialog](https://github.com/mlabbe/nativefiledialog) ([zlib](https://github.com/mlabbe/nativefiledialog/blob/master/LICENSE))
 - [nlohmann_json](https://github.com/nlohmann/json) ([MIT](https://github.com/nlohmann/json/blob/develop/LICENSE.MIT))
 - [box2d](https://github.com/erincatto/box2d) ([MIT](https://github.com/erincatto/box2d/blob/main/LICENSE))
+
+### Dependencies
+
+You need to install the following dependencies to build the project:
+
+- [CMake](https://cmake.org/download/) v3.22 or higher
+- [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) v1.3.268 or higher
+- [Boost](https://www.boost.org/) v1.82 or higher
 
 ### To build manually
 
@@ -49,11 +48,11 @@ make docker_cleanup     # Remove docker container (optional)
 ### To run custom command inside docker container
 
 ```bash
-make DOCKER_CMD="make clang-tidy CLANG_TIDY_BIN=clang-tidy-11" docker_run
+make DOCKER_CMD="make clang-tidy" docker_run
 ```
 
-You can use `CLANG_FORMAT_BIN` and `RUN_CLANG_TIDY_BIN` `make` options to pass path to
-appropriate binary file.
+You can use `CLANG_FORMAT_BIN` and `RUN_CLANG_TIDY_BIN` `make` options to pass
+path to an appropriate binary file.
 
 ### Linters
 
@@ -76,36 +75,41 @@ You don't need to install additional libraries to build or run examples or
 applications. All you need to do is to set appropriate environment variables
 depending on OS type.
 
-At the moment `VK_LAYER_PATH` should only be configured for `Debug` or
-`RelWithDebInfo` build types, to configure `Vulkan-ValidationLayers`.
+*Notes:*
+
+- `VK_LAYER_PATH` should point to the directory where
+  `VK_LAYER_LUNARG_standard_validation.json` is located
+- For MacOS `VK_ICD_FILENAMES` should point to the directory where
+  `MoltenVK_icd.json`
 
 #### Linux
 
 ```bash
-export VK_LAYER_PATH=build/_deps/vulkan-validationlayers-build/layers
+export VK_ADD_LAYER_PATH=${VULKAN_SDK}/share/vulkan/explicit_layer.d
 build/examples/sandbox/sandbox -e gui
 ```
 
 #### MacOS
 
 ```bash
-export VK_LAYER_PATH=build/_deps/vulkan-validationlayers-build/layers
-export VK_ICD_FILENAMES=build/_deps/moltenvk-src/Package/Latest/MoltenVK/dynamic/dylib/macOS/MoltenVK_icd.json
+export VK_ADD_LAYER_PATH=${VULKAN_SDK}/share/vulkan/explicit_layer.d
+export VK_ICD_FILENAMES=${VULKAN_SDK}/share/vulkan/icd.d/MoltenVK_icd.json
 build/examples/sandbox/sandbox -e gui
 ```
 
 ### genesis build options
 
-| Make | CMake | Default value| Description |
-|------|-------|--------------|-------------|
-| `BUILD_TYPE` | `CMAKE_BUILD_TYPE` | `Release` | Project build types: `Release`, `Debug`, `ASAN`, `USAN`, `TSAN` |
-| `BUILD_STATIC` | `GE_STATIC` | `OFF` | Build static library |
-| `DISABLE_ASSERTS` | `GE_DISABLE_ASSERTS` | `OFF` | Exclude asserts from final binary |
-| `BUILD_EXAMPLES` | `GE_BUILD_EXAMPLES` | `OFF` | Build examples |
-| `BUILD_TESTS` | `GE_BUILD_TESTS` | `OFF` | Build tests |
-| `CLANG_FORMAT_BIN` | - | `clang-format` | Path to `clang-format` binary |
-| `RUN_CLANG_TIDY_BIN` | - | `run-clang-tidy` | Path to `run-clang-tidy` tool |
-| `DOCKER_CMD` | - | `make -j$(nproc)` | Command which will be executed by `make docker_run` |
+| Make                 | CMake                | Default value     | Description                                                                       |
+|----------------------|----------------------|-------------------|-----------------------------------------------------------------------------------|
+| `BUILD_TYPE`         | `CMAKE_BUILD_TYPE`   | `Release`         | Project build types: `Release`, `Debug`, `RelWithDebInfo`, `ASAN`, `USAN`, `TSAN` |
+| `BUILD_STATIC`       | `GE_STATIC`          | `OFF`             | Build static library                                                              |
+| `DISABLE_ASSERTS`    | `GE_DISABLE_ASSERTS` | `OFF`             | Exclude asserts from final binary                                                 |
+| `BUILD_APPS`         | `GE_BUILD_APPS`      | `OFF`             | Build applications                                                                |
+| `BUILD_EXAMPLES`     | `GE_BUILD_EXAMPLES`  | `OFF`             | Build examples                                                                    |
+| `BUILD_TESTS`        | `GE_BUILD_TESTS`     | `OFF`             | Build tests                                                                       |
+| `CLANG_FORMAT_BIN`   | -                    | `clang-format`    | Path to `clang-format` binary                                                     |
+| `RUN_CLANG_TIDY_BIN` | -                    | `run-clang-tidy`  | Path to `run-clang-tidy` tool                                                     |
+| `DOCKER_CMD`         | -                    | `make -j$(nproc)` | Command which will be executed by `make docker_run`                               |
 
 ### Licence
 

--- a/apps/level-editor/CMakeLists.txt
+++ b/apps/level-editor/CMakeLists.txt
@@ -69,7 +69,7 @@ ge_add_executable(level_editor
     SOURCES ${LEVEL_EDITOR_SOURCES} ${LEVEL_EDITOR_HEADERS}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE_DEPS
-        Boost::circular_buffer
+        Boost::boost
         docopt_s
         genesis::genesis
         nlohmann_json::nlohmann_json

--- a/cmake/find-modules/Findge-shaderc_combined.cmake
+++ b/cmake/find-modules/Findge-shaderc_combined.cmake
@@ -1,0 +1,26 @@
+# Find headers
+find_path(GE_SHADERC_INCLUDE_DIR shaderc/shaderc.hpp
+    HINTS $ENV{VULKAN_SDK}
+    PATH_SUFFIXES include
+)
+
+# Find the library
+find_library(GE_SHADERC_COMBINED_LIBRARY
+    NAMES shaderc_combined
+    HINTS $ENV{VULKAN_SDK}
+    PATH_SUFFIXES lib
+)
+
+# Verify variables
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GE_SHADERC_COMBINED
+    REQUIRED_VARS GE_SHADERC_COMBINED_LIBRARY
+                  GE_SHADERC_INCLUDE_DIR
+    )
+
+# Create imported targets
+add_library(shaderc_combined STATIC IMPORTED)
+set_target_properties(shaderc_combined PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${GE_SHADERC_INCLUDE_DIR}
+    IMPORTED_LOCATION             ${GE_SHADERC_COMBINED_LIBRARY}
+    )

--- a/cmake/find-modules/Findge-spirv-cross.cmake
+++ b/cmake/find-modules/Findge-spirv-cross.cmake
@@ -1,0 +1,42 @@
+# Find headers
+find_path(GE_SPIRV_CROSS_INCLUDE_DIR spirv_cross/spirv_cross.hpp
+    HINTS $ENV{VULKAN_SDK}
+    PATH_SUFFIXES include
+    )
+
+# Find SPIRV-Cross core library
+find_library(GE_SPIRV_CROSS_CORE_LIBRARY
+    NAMES spirv-cross-core
+    HINTS $ENV{VULKAN_SDK}
+    PATH_SUFFIXES lib
+    )
+
+# Find SPIRV-Cross cpp library
+find_library(GE_SPIRV_CROSS_CPP_LIBRARY
+    NAMES spirv-cross-cpp
+    HINTS $ENV{VULKAN_SDK}
+    PATH_SUFFIXES lib
+    )
+
+# Verify variables
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GE_SPIRV_CROSS
+    REQUIRED_VARS GE_SPIRV_CROSS_CORE_LIBRARY
+                  GE_SPIRV_CROSS_CPP_LIBRARY
+                  GE_SPIRV_CROSS_INCLUDE_DIR
+    )
+
+# Create imported targets
+add_library(spirv-cross-core STATIC IMPORTED)
+set_target_properties(spirv-cross-core PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${GE_SPIRV_CROSS_INCLUDE_DIR}
+    IMPORTED_LOCATION             ${GE_SPIRV_CROSS_CORE_LIBRARY}
+    )
+
+add_library(spirv-cross-cpp STATIC IMPORTED)
+set_target_properties(spirv-cross-cpp PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${GE_SPIRV_CROSS_INCLUDE_DIR}
+    INTERFACE_LINK_LIBRARIES      spirv-cross-core
+    IMPORTED_LOCATION             ${GE_SPIRV_CROSS_CPP_LIBRARY}
+    )
+

--- a/examples/sdl2-vulkan/CMakeLists.txt
+++ b/examples/sdl2-vulkan/CMakeLists.txt
@@ -4,9 +4,8 @@ ge_add_executable(sdl2_vulkan_example
         genesis::core
         glm
         SDL2::SDL2-static
-        shaderc_shared
+        shaderc_combined
         stb-image
         tinyobjloader
-        Vulkan::Headers
-        Vulkan::Loader
+        Vulkan::Vulkan
     )

--- a/src/genesis/assets/CMakeLists.txt
+++ b/src/genesis/assets/CMakeLists.txt
@@ -33,5 +33,5 @@ ge_add_module(assets
         genesis::graphics
         yaml-cpp::yaml-cpp
     PRIVATE_DEPS
-        Boost::uuid
+        Boost::boost
     )

--- a/src/genesis/core/CMakeLists.txt
+++ b/src/genesis/core/CMakeLists.txt
@@ -29,7 +29,7 @@ ge_add_module(core
     SOURCES ${CORE_SOURCES} ${CORE_HEADERS}
     INCLUDE_DIRS ${INCLUDE_DIR}
     PUBLIC_DEPS
-        Boost::mpl
+        Boost::boost
         fmt::fmt
         magic_enum::magic_enum
         spdlog::spdlog

--- a/src/genesis/graphics/CMakeLists.txt
+++ b/src/genesis/graphics/CMakeLists.txt
@@ -52,7 +52,7 @@ ge_add_module(graphics
         genesis::math
     PRIVATE_DEPS
         genesis::graphics-vulkan
-        shaderc
+        shaderc_combined
         spirv-cross-cpp
         stb-image
         tinyobjloader

--- a/src/genesis/graphics/shader_reflection.cpp
+++ b/src/genesis/graphics/shader_reflection.cpp
@@ -34,7 +34,7 @@
 
 #include "genesis/core/utils.h"
 
-#include <spirv_cross.hpp>
+#include <spirv_cross/spirv_cross.hpp>
 
 using AttrType = GE::shader_attribute_t::BaseType;
 using DescType = GE::resource_descriptor_t::Type;

--- a/src/genesis/graphics/vulkan/CMakeLists.txt
+++ b/src/genesis/graphics/vulkan/CMakeLists.txt
@@ -70,12 +70,11 @@ ge_add_module(graphics-vulkan
         genesis::graphics
         genesis::math
         genesis::window
-        Vulkan::Headers
-        Vulkan::Loader
+        Vulkan::Vulkan
     PRIVATE_DEPS
         ge-imgui-vulkan
         SDL2::SDL2-static
-        shaderc
+        shaderc_combined
         spirv-cross-cpp
         stb-image
     )

--- a/src/genesis/gui/CMakeLists.txt
+++ b/src/genesis/gui/CMakeLists.txt
@@ -78,7 +78,7 @@ ge_add_module(gui
         ${INCLUDE_DIR}/widgets
         ${CMAKE_CURRENT_SOURCE_DIR}
     PUBLIC_DEPS
-        Boost::signals2
+        Boost::boost
         genesis::app
     PRIVATE_DEPS
         genesis::graphics

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -133,12 +133,6 @@ FetchContent_Declare(docopt.cpp
     GIT_TAG v0.6.3)
 FetchContent_MakeAvailable(docopt.cpp)
 
-# boost
-FetchContent_Declare(boost
-    GIT_REPOSITORY https://github.com/boostorg/boost.git
-    GIT_TAG boost-1.82.0)
-FetchContent_MakeAvailable(boost)
-
 # yaml-cpp
 FetchContent_Declare(yaml-cpp
     GIT_REPOSITORY https://github.com/hogletgames/yaml-cpp.git

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,6 +1,7 @@
-include(FetchContent)
 include(ExternalProject)
+include(FetchContent)
 
+# Get number of logical cores
 cmake_host_system_information(RESULT GE_NPROC QUERY NUMBER_OF_LOGICAL_CORES)
 
 # CMake options
@@ -15,12 +16,6 @@ set(YAML_CPP_BUILD_TOOLS OFF)
 set(YAML_BUILD_SHARED_LIBS OFF)
 set(YAML_CPP_INSTALL OFF)
 set(YAML_CPP_FORMAT_SOURCE OFF)
-
-# Vulkan SDK
-set(UPDATE_DEPS ON)
-set(ENABLE_CTEST OFF)
-set(SHADERC_SKIP_TESTS ON)
-set(ALLOW_EXTERNAL_SPIRV_TOOLS ON)
 
 # Box2D
 set(BOX2D_BUILD_UNIT_TESTS OFF)
@@ -90,8 +85,7 @@ if (NOT imgui_POPULATED)
     target_link_libraries(ge-imgui-vulkan PUBLIC
         ge-imgui
         SDL2-static
-        Vulkan::Headers
-        Vulkan::Loader
+        Vulkan::Vulkan
         )
     target_include_directories(ge-imgui-vulkan PUBLIC ${imgui_SOURCE_DIR}/backends)
 
@@ -279,8 +273,4 @@ if (GE_BUILD_TESTS)
         GIT_REPOSITORY https://github.com/hogletgames/googletest.git
         GIT_TAG release-1.12.1)
     FetchContent_MakeAvailable(googletest)
-endif ()
-
-if (NOT GE_DISABLE_DEBUG)
-    add_dependencies(vulkan vvl)
 endif ()

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -184,87 +184,11 @@ FetchContent_Declare(nlohmann_json
     URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
 FetchContent_MakeAvailable(nlohmann_json)
 
-# Vulkan-Loader
-FetchContent_Declare(Vulkan-Loader
-    GIT_REPOSITORY https://github.com/hogletgames/Vulkan-Loader.git
-    GIT_TAG vulkan-sdk-1.3.268.0)
-ge_change_build_type(Release)
-FetchContent_MakeAvailable(Vulkan-Loader)
-ge_restore_build_type()
-
-# glslang
-FetchContent_Declare(glslang
-    GIT_REPOSITORY https://github.com/hogletgames/glslang.git
-    GIT_TAG vulkan-sdk-1.3.268.0)
-FetchContent_MakeAvailable(glslang)
-
-# SPIRV-Headers
-FetchContent_Declare(SPIRV-Headers
-    GIT_REPOSITORY https://github.com/hogletgames/SPIRV-Headers.git
-    GIT_TAG vulkan-sdk-1.3.268.0)
-FetchContent_MakeAvailable(SPIRV-Headers)
-
-# SPIRV-Tools
-FetchContent_Declare(SPIRV-Tools
-    GIT_REPOSITORY https://github.com/hogletgames/SPIRV-Tools.git
-    GIT_TAG vulkan-sdk-1.3.268.0)
-FetchContent_MakeAvailable(SPIRV-Tools)
-target_compile_options(SPIRV-Tools-opt PRIVATE $<$<CONFIG:USAN>:-fno-sanitize=vptr>)
-
-# SPIRV-Cross
-FetchContent_Declare(SPIRV-Cross
-    GIT_REPOSITORY https://github.com/hogletgames/SPIRV-Cross.git
-    GIT_TAG vulkan-sdk-1.3.268.0)
-FetchContent_MakeAvailable(SPIRV-Cross)
-
-# Vulkan-ValidationLayers
-FetchContent_Declare(Vulkan-ValidationLayers
-    GIT_REPOSITORY https://github.com/hogletgames/Vulkan-ValidationLayers.git
-    GIT_TAG vulkan-sdk-1.3.268.0)
-ge_change_build_type(Release)
-FetchContent_MakeAvailable(Vulkan-ValidationLayers)
-ge_restore_build_type()
-
-# shaderc
-FetchContent_Declare(shaderc
-    GIT_REPOSITORY https://github.com/hogletgames/shaderc.git
-    GIT_TAG v2023.7)
-FetchContent_MakeAvailable(shaderc)
-
-# Vulkan-Headers
-FetchContent_Declare(Vulkan-Headers
-    GIT_REPOSITORY https://github.com/hogletgames/Vulkan-Headers.git
-    GIT_TAG vulkan-sdk-1.3.268.0)
-FetchContent_MakeAvailable(Vulkan-Headers)
-
 # box2d
 FetchContent_Declare(box2d
     GIT_REPOSITORY https://github.com/hogletgames/box2d.git
     GIT_TAG v3.0.0)
 FetchContent_MakeAvailable(box2d)
-
-# Apple dependencies
-if (APPLE)
-    # MoltenVK
-    FetchContent_Declare(MoltenVK
-        GIT_REPOSITORY https://github.com/hogletgames/MoltenVK.git
-        GIT_TAG v1.2.8)
-    FetchContent_GetProperties(MoltenVK)
-    if (NOT moltenvk_POPULATED)
-        FetchContent_Populate(MoltenVK)
-
-        set(MOLTENVK_ICD ${moltenvk_SOURCE_DIR}/Package/Latest/MoltenVK/dynamic/dylib/macOS/MoltenVK_icd.json)
-        add_custom_command(OUTPUT ${MOLTENVK_ICD}
-            COMMAND ./fetchDependencies -v --macos
-            COMMAND make -j${GE_NPROC} macos
-            WORKING_DIRECTORY ${moltenvk_SOURCE_DIR}
-            BYPRODUCTS ${MOLTENVK_ICD}
-            VERBATIM)
-
-        add_custom_target(MoltenVkIcd DEPENDS ${MOLTENVK_ICD})
-        add_dependencies(vulkan MoltenVkIcd)
-    endif()
-endif ()
 
 # Project dependencies
 if (GE_BUILD_TESTS)

--- a/tools/install_boost_linux.sh
+++ b/tools/install_boost_linux.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+INSTALL_PREFIX="${1:-/opt/boost}"
+
+BOOST_URL=https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.gz
+BOOST_DEST_ARCHIVE=/tmp/boost.tar.gz
+BOOST_SHA256="66a469b6e608a51f8347236f4912e27dc5c60c60d7d53ae9bfe4683316c6f04c"
+
+# Download and extract the Boost library
+wget -O "${BOOST_DEST_ARCHIVE}" "${BOOST_URL}"
+echo "${BOOST_SHA256} ${BOOST_DEST_ARCHIVE}" | sha256sum -c
+tar -xzf "${BOOST_DEST_ARCHIVE}" -C /tmp
+
+# Install the Boost library
+cd /tmp/boost_1_82_0
+./bootstrap.sh --prefix="${INSTALL_PREFIX}"
+./b2 install
+
+# Clean up
+rm -rf /tmp/boost_1_82_0 "${BOOST_DEST_ARCHIVE}"

--- a/tools/install_vulkan_sdk_linux.sh
+++ b/tools/install_vulkan_sdk_linux.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+VULKAN_SDK_VERSION="1.3.268.0"
+EXPECTED_SHA256="d23343736247828ff5b3b6b1b7fd83a72b5df1a54b2527ae3663cebdfee75842"
+
+VULKAN_SDK_ARCHIVE_NAME="vulkansdk-linux-x86_64-${VULKAN_SDK_VERSION}.tar.xz"
+VULKAN_SDK_URL="https://sdk.lunarg.com/sdk/download/${VULKAN_SDK_VERSION}/linux/${VULKAN_SDK_ARCHIVE_NAME}"
+VULKAN_SDK_DOWNLOAD_DEST="/tmp/vulkan-sdk.tar.xz"
+VULKAN_SDK_INSTALL_DEST="/opt/vulkan-sdk"
+
+# Download the Vulkan SDK
+wget -O "${VULKAN_SDK_DOWNLOAD_DEST}" "${VULKAN_SDK_URL}"
+
+# Verify the SHA256 checksum
+sha256 -c "${EXPECTED_SHA256}" "${VULKAN_SDK_DOWNLOAD_DEST}"
+
+# Extract the Vulkan SDK
+tar -xf "${VULKAN_SDK_DOWNLOAD_DEST}" -C /opt
+
+# Append to the user's .bashrc
+echo "source ${VULKAN_SDK_INSTALL_DEST}/${VULKAN_SDK_VERSION}/setup-env.sh" >> ~/.bashrc
+
+# Cleanup
+rm "${VULKAN_SDK_DOWNLOAD_DEST}"


### PR DESCRIPTION
- Added scripts to build and install Vukan SDK and boost
- Added cmake moduels for shaderc and spirv-cross
- Replaced fetched Vulkan SDK and boost with preinstalled
- Updated Docker
- Run `clang-tidy` for PRs only