### PR TITLE
Update formatting rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,11 +2,19 @@
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: true
+  AlignFunctionDeclarations: false
+  PadOperators: true
 AlignConsecutiveMacros: true
-AlignEscapedNewlines: Left
-AlignOperands:   true
+AlignConsecutiveShortCaseStatements:
+  Enabled: false
+AlignEscapedNewlines: Right
+AlignOperands: true
 AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
@@ -18,7 +26,7 @@ AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
-BinPackParameters: true
+BinPackParameters: OnePerLine
 BraceWrapping:
   AfterClass:      true
   AfterControlStatement: false
@@ -49,7 +57,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
@@ -87,7 +95,7 @@ PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyReturnTypeOnItsOwnLine: 80
 PointerAlignment: Left
 ReflowComments:  true
 SortIncludes:    true

--- a/apps/level-editor/gui/level_editor_gui.h
+++ b/apps/level-editor/gui/level_editor_gui.h
@@ -73,11 +73,11 @@ private:
     void createPanels();
     void createWindows();
 
-    LevelEditorContext* m_ctx{nullptr};
-    MenuBar m_menu_bar;
-    Toolbar m_toolbar;
-    GE::GUI::WindowMap m_panels;
-    GE::GUI::WindowMap m_windows;
+    LevelEditorContext*   m_ctx{nullptr};
+    MenuBar               m_menu_bar;
+    Toolbar               m_toolbar;
+    GE::GUI::WindowMap    m_panels;
+    GE::GUI::WindowMap    m_windows;
     GE::GUI::ModalWindows m_modals;
 
     ViewportChangedSignal m_viewport_changed_signal;

--- a/apps/level-editor/gui/main_menu/menu_bar.cpp
+++ b/apps/level-editor/gui/main_menu/menu_bar.cpp
@@ -41,7 +41,7 @@ using namespace GE::GUI;
 
 namespace LE {
 
-MenuBar::MenuBar(LevelEditorGUI *gui)
+MenuBar::MenuBar(LevelEditorGUI* gui)
     : m_project{GE::makeShared<ProjectMenu>(gui->context()->settings())}
     , m_assets{GE::makeShared<AssetsMenu>()}
     , m_scene{GE::makeShared<SceneMenu>()}
@@ -58,7 +58,7 @@ void MenuBar::onUpdate(GE::Timestamp ts)
     m_menus.onUpdate(ts);
 }
 
-void MenuBar::onEvent(GE::Event *event)
+void MenuBar::onEvent(GE::Event* event)
 {
     m_menus.onEvent(event);
 }
@@ -66,7 +66,7 @@ void MenuBar::onEvent(GE::Event *event)
 void MenuBar::onRender()
 {
     MainMenuBar bar;
-    WidgetNode bar_node{&bar};
+    WidgetNode  bar_node{&bar};
     m_menus.onRender(&bar_node);
 }
 

--- a/apps/level-editor/gui/main_menu/menu_bar.h
+++ b/apps/level-editor/gui/main_menu/menu_bar.h
@@ -68,9 +68,9 @@ private:
     GE::GUI::MenuList m_menus;
 
     GE::Shared<ProjectMenu> m_project;
-    GE::Shared<AssetsMenu> m_assets;
-    GE::Shared<SceneMenu> m_scene;
-    GE::Shared<ViewMenu> m_view;
+    GE::Shared<AssetsMenu>  m_assets;
+    GE::Shared<SceneMenu>   m_scene;
+    GE::Shared<ViewMenu>    m_view;
 };
 
 } // namespace LE

--- a/apps/level-editor/gui/main_menu/project_menu.h
+++ b/apps/level-editor/gui/main_menu/project_menu.h
@@ -56,8 +56,8 @@ private:
     Settings* m_settings{nullptr};
 
     SaveFileSignal m_save_signal;
-    SaveSignal m_save_as_signal;
-    LoadSignal m_load_signal;
+    SaveSignal     m_save_as_signal;
+    LoadSignal     m_load_signal;
     LoadFileSignal m_load_recent_signal;
 };
 

--- a/apps/level-editor/gui/main_menu/scene_menu.cpp
+++ b/apps/level-editor/gui/main_menu/scene_menu.cpp
@@ -38,7 +38,7 @@ using namespace GE::GUI;
 
 namespace LE {
 
-void SceneMenu::onRender(WidgetNode *bar_node)
+void SceneMenu::onRender(WidgetNode* bar_node)
 {
     auto menu = bar_node->makeSubNode<Menu>("Scene");
     if (menu.call<MenuItem>("Load...")) {

--- a/apps/level-editor/gui/main_menu/view_menu.cpp
+++ b/apps/level-editor/gui/main_menu/view_menu.cpp
@@ -39,17 +39,17 @@ using namespace GE::GUI;
 
 namespace LE {
 
-ViewMenu::ViewMenu(WindowMap *panels)
+ViewMenu::ViewMenu(WindowMap* panels)
     : m_panels{panels}
 {}
 
-void ViewMenu::onRender(WidgetNode *bar_node)
+void ViewMenu::onRender(WidgetNode* bar_node)
 {
     auto view_menu = bar_node->makeSubNode<Menu>("View");
     drawPanels(&view_menu);
 }
 
-void ViewMenu::drawPanels(WidgetNode *view_node)
+void ViewMenu::drawPanels(WidgetNode* view_node)
 {
     static constexpr std::array PANEL_NAMES = {
         EditorCameraPanel::NAME, AssetsPanel::NAME,     ViewportPanel::NAME,
@@ -57,8 +57,8 @@ void ViewMenu::drawPanels(WidgetNode *view_node)
     };
 
     auto panels_menu = view_node->makeSubNode<Menu>("Panels");
-    for (const char *panel_name : PANEL_NAMES) {
-        if (auto *panel = m_panels->get(panel_name);
+    for (const char* panel_name : PANEL_NAMES) {
+        if (auto* panel = m_panels->get(panel_name);
             panels_menu.call<MenuItem>(panel_name, "", panel->isOpen())) {
             panel->setIsOpen(!panel->isOpen());
         }

--- a/apps/level-editor/gui/panels/assets_panel.cpp
+++ b/apps/level-editor/gui/panels/assets_panel.cpp
@@ -47,7 +47,7 @@ namespace {
 
 constexpr TreeNode::Flags TREE_NODE_FLAGS{TreeNode::SPAN_AVAIL_WIDTH | TreeNode::FRAME_PADDING};
 
-GE::Vec2 scaledTextureSize(const GE::Vec2 &texture_size, float window_width)
+GE::Vec2 scaledTextureSize(const GE::Vec2& texture_size, float window_width)
 {
     float scale = window_width / texture_size.x;
     return texture_size * scale;
@@ -55,17 +55,17 @@ GE::Vec2 scaledTextureSize(const GE::Vec2 &texture_size, float window_width)
 
 } // namespace
 
-void DeferredAssetsPanelCommands::removePackage(const std::string &name)
+void DeferredAssetsPanelCommands::removePackage(const std::string& name)
 {
     enqueue([this, name] { m_assets->removePackage(name); });
 }
 
-void DeferredAssetsPanelCommands::removeResource(const ResourceID &id)
+void DeferredAssetsPanelCommands::removeResource(const ResourceID& id)
 {
     enqueue([this, id] { m_assets->removeResource(id); });
 }
 
-AssetsPanel::AssetsPanel(Registry *assets)
+AssetsPanel::AssetsPanel(Registry* assets)
     : WindowBase{NAME}
     , m_assets{assets}
     , m_commands(assets)
@@ -86,7 +86,7 @@ void AssetsPanel::updateWindowParameters()
     m_window_size = m_window.availableRegion();
 }
 
-void AssetsPanel::drawContextMenu(WidgetNode *node)
+void AssetsPanel::drawContextMenu(WidgetNode* node)
 {
     auto flags = PopupFlag::MOUSE_BUTTON_RIGHT | PopupFlag::NO_OPEN_OVER_ITEMS |
                  PopupFlag::NO_OPEN_OVER_EXISTING_POPUP;
@@ -105,7 +105,7 @@ void AssetsPanel::drawContextMenu(WidgetNode *node)
     }
 }
 
-void AssetsPanel::drawAssets(WidgetNode *node)
+void AssetsPanel::drawAssets(WidgetNode* node)
 {
     if (!node->isOpened()) {
         return;
@@ -113,14 +113,14 @@ void AssetsPanel::drawAssets(WidgetNode *node)
 
     auto packages = m_assets->allPackages();
     std::ranges::sort(packages,
-                      [](const auto *lhs, const auto *rhs) { return lhs->name() < rhs->name(); });
+                      [](const auto* lhs, const auto* rhs) { return lhs->name() < rhs->name(); });
 
-    for (const auto *package : packages) {
+    for (const auto* package : packages) {
         drawPackage(node, *package);
     }
 }
 
-void AssetsPanel::drawPackage(WidgetNode *node, const Package &package)
+void AssetsPanel::drawPackage(WidgetNode* node, const Package& package)
 {
     auto package_node = node->makeSubNode<TreeNode>(package.name(), TREE_NODE_FLAGS);
 
@@ -136,7 +136,7 @@ void AssetsPanel::drawPackage(WidgetNode *node, const Package &package)
     }
 }
 
-void AssetsPanel::drawResource(WidgetNode *node, const GE::Shared<MeshResource> &resource)
+void AssetsPanel::drawResource(WidgetNode* node, const GE::Shared<MeshResource>& resource)
 {
     auto mesh_node = node->makeSubNode<TreeNode>(resource->id().name(), TREE_NODE_FLAGS);
     mesh_node.call<Text>("Use count: %d", resource->mesh().use_count());
@@ -148,7 +148,7 @@ void AssetsPanel::drawResource(WidgetNode *node, const GE::Shared<MeshResource> 
     }
 }
 
-void AssetsPanel::drawResource(WidgetNode *node, const GE::Shared<PipelineResource> &resource)
+void AssetsPanel::drawResource(WidgetNode* node, const GE::Shared<PipelineResource>& resource)
 {
     auto pipeline_node = node->makeSubNode<TreeNode>(resource->id().name(), TREE_NODE_FLAGS);
 
@@ -174,9 +174,9 @@ void AssetsPanel::drawResource(WidgetNode *node, const GE::Shared<PipelineResour
     }
 }
 
-void AssetsPanel::drawResource(WidgetNode *node, const GE::Shared<TextureResource> &resource)
+void AssetsPanel::drawResource(WidgetNode* node, const GE::Shared<TextureResource>& resource)
 {
-    auto *texture = resource->texture().get();
+    auto* texture = resource->texture().get();
 
     auto texture_node = node->makeSubNode<TreeNode>(resource->id().name(), TREE_NODE_FLAGS);
     texture_node.call<Text>("Use count: %d", resource->texture().use_count());
@@ -192,7 +192,7 @@ void AssetsPanel::drawResource(WidgetNode *node, const GE::Shared<TextureResourc
 }
 
 template<typename T>
-void AssetsPanel::drawResources(WidgetNode *node, const Package &package)
+void AssetsPanel::drawResources(WidgetNode* node, const Package& package)
 {
     auto resources = package.getAllOf<T>();
     if (resources.empty()) {
@@ -205,7 +205,7 @@ void AssetsPanel::drawResources(WidgetNode *node, const Package &package)
         return;
     }
 
-    for (const auto &resource : resources) {
+    for (const auto& resource : resources) {
         drawResource(&resources_node, resource);
     }
 }

--- a/apps/level-editor/gui/panels/assets_panel.h
+++ b/apps/level-editor/gui/panels/assets_panel.h
@@ -88,18 +88,18 @@ private:
     void drawContextMenu(GE::GUI::WidgetNode* node);
     void drawAssets(GE::GUI::WidgetNode* node);
     void drawPackage(GE::GUI::WidgetNode* node, const GE::Assets::Package& package);
-    void drawResource(GE::GUI::WidgetNode* node,
+    void drawResource(GE::GUI::WidgetNode*                        node,
                       const GE::Shared<GE::Assets::MeshResource>& resource);
-    void drawResource(GE::GUI::WidgetNode* node,
+    void drawResource(GE::GUI::WidgetNode*                            node,
                       const GE::Shared<GE::Assets::PipelineResource>& resource);
-    void drawResource(GE::GUI::WidgetNode* node,
+    void drawResource(GE::GUI::WidgetNode*                           node,
                       const GE::Shared<GE::Assets::TextureResource>& resource);
 
     template<typename T>
     void drawResources(GE::GUI::WidgetNode* node, const GE::Assets::Package& package);
 
     GE::Assets::Registry* m_assets{nullptr};
-    GE::Vec2 m_window_size{0.0f, 0.0f};
+    GE::Vec2              m_window_size{0.0f, 0.0f};
 
     DeferredAssetsPanelCommands m_commands;
 

--- a/apps/level-editor/gui/panels/components_panel.cpp
+++ b/apps/level-editor/gui/panels/components_panel.cpp
@@ -47,20 +47,20 @@ namespace LE {
 namespace {
 
 template<typename T>
-const char *isLoaded(const GE::Shared<T> &resource)
+const char* isLoaded(const GE::Shared<T>& resource)
 {
     return resource != nullptr ? "loaded" : "null";
 }
 
 template<typename T>
-bool isNewComponentSuitable(const Entity &entity)
+bool isNewComponentSuitable(const Entity& entity)
 {
     return !entity.has<T>();
 }
 
 } // namespace
 
-ComponentsPanel::ComponentsPanel(LevelEditorContext *ctx)
+ComponentsPanel::ComponentsPanel(LevelEditorContext* ctx)
     : WindowBase{NAME}
     , m_ctx{ctx}
 {}
@@ -74,9 +74,9 @@ void ComponentsPanel::onRender()
     }
 }
 
-void ComponentsPanel::drawEntityComponents(Entity *entity)
+void ComponentsPanel::drawEntityComponents(Entity* entity)
 {
-    GE::forEachType<ComponentList>([this, entity](const auto &component) {
+    GE::forEachType<ComponentList>([this, entity](const auto& component) {
         using Component = std::decay_t<decltype(component)>;
         if (entity->has<Component>()) {
             draw<Component>(entity);
@@ -84,7 +84,7 @@ void ComponentsPanel::drawEntityComponents(Entity *entity)
     });
 }
 
-void ComponentsPanel::drawAddNewComponents(WidgetNode *node, Entity *entity)
+void ComponentsPanel::drawAddNewComponents(WidgetNode* node, Entity* entity)
 {
     constexpr std::string_view ADD_COMPONENT_POPUP{"add_component_popup"};
 
@@ -93,7 +93,7 @@ void ComponentsPanel::drawAddNewComponents(WidgetNode *node, Entity *entity)
     }
 
     auto add_component_popup = WidgetNode::create<Popup>(ADD_COMPONENT_POPUP);
-    GE::forEachType<ComponentList>([&add_component_popup, entity](const auto &component) {
+    GE::forEachType<ComponentList>([&add_component_popup, entity](const auto& component) {
         using Component = std::decay_t<decltype(component)>;
 
         if (isNewComponentSuitable<Component>(*entity) &&
@@ -105,7 +105,7 @@ void ComponentsPanel::drawAddNewComponents(WidgetNode *node, Entity *entity)
 }
 
 template<typename Component>
-void ComponentsPanel::draw(Entity *entity)
+void ComponentsPanel::draw(Entity* entity)
 {
     auto flags = TreeNode::DEFAULT_OPEN | TreeNode::FRAMED | TreeNode::SPAN_AVAIL_WIDTH |
                  TreeNode::ALLOW_ITEM_OVERLAP | TreeNode::FRAME_PADDING;
@@ -119,7 +119,7 @@ void ComponentsPanel::draw(Entity *entity)
     }
 }
 
-void ComponentsPanel::draw(WidgetNode *node, CameraComponent *camera)
+void ComponentsPanel::draw(WidgetNode* node, CameraComponent* camera)
 {
     bool is_primary_camera = *m_ctx->selectedEntity() == m_ctx->scene()->mainCamera();
 
@@ -130,7 +130,7 @@ void ComponentsPanel::draw(WidgetNode *node, CameraComponent *camera)
     node->call<Checkbox>("Fixed aspect ratio", &camera->fixed_aspect_ratio);
 }
 
-void ComponentsPanel::draw(WidgetNode *node, MaterialComponent *material)
+void ComponentsPanel::draw(WidgetNode* node, MaterialComponent* material)
 {
     auto material_id = material->materialID().asString();
 
@@ -141,12 +141,12 @@ void ComponentsPanel::draw(WidgetNode *node, MaterialComponent *material)
     }
 }
 
-void ComponentsPanel::draw(WidgetNode *node, TagComponent *tag)
+void ComponentsPanel::draw(WidgetNode* node, TagComponent* tag)
 {
     node->call<InputText>("Tag", &tag->tag);
 }
 
-void ComponentsPanel::draw(WidgetNode *node, TransformComponent *transform)
+void ComponentsPanel::draw(WidgetNode* node, TransformComponent* transform)
 {
     node->call<ValueEditor>("Translation", &transform->translation, 0.05f, -10.0f, 10.0f);
     if (auto angles = GE::degrees(transform->rotation);
@@ -156,7 +156,7 @@ void ComponentsPanel::draw(WidgetNode *node, TransformComponent *transform)
     node->call<ValueEditor>("Scale", &transform->scale, 0.1, 0.0f, 10.0f);
 }
 
-void ComponentsPanel::draw(WidgetNode *node, SpriteComponent *sprite)
+void ComponentsPanel::draw(WidgetNode* node, SpriteComponent* sprite)
 {
     auto mesh_id = sprite->meshID().asString();
     auto texture_id = sprite->textureID().asString();
@@ -168,7 +168,7 @@ void ComponentsPanel::draw(WidgetNode *node, SpriteComponent *sprite)
     }
 }
 
-void ComponentsPanel::draw(WidgetNode *node, RigidBody2DComponent *rigid_body)
+void ComponentsPanel::draw(WidgetNode* node, RigidBody2DComponent* rigid_body)
 {
     static const std::vector<std::string> BODY_TYPES = {
         GE::toString(RigidBody::Type::STATIC),
@@ -176,7 +176,7 @@ void ComponentsPanel::draw(WidgetNode *node, RigidBody2DComponent *rigid_body)
         GE::toString(RigidBody::Type::KINEMATIC),
     };
 
-    auto type_string = GE::toString(rigid_body->body_type);
+    auto     type_string = GE::toString(rigid_body->body_type);
     ComboBox type_combo{"Type", BODY_TYPES, type_string};
     node->subNode(&type_combo);
 
@@ -187,17 +187,17 @@ void ComponentsPanel::draw(WidgetNode *node, RigidBody2DComponent *rigid_body)
     node->call<Checkbox>("Fixed rotation", &rigid_body->fixed_rotation);
 }
 
-void ComponentsPanel::draw(WidgetNode *node, body_shape_config_base_t *shape_config)
+void ComponentsPanel::draw(WidgetNode* node, body_shape_config_base_t* shape_config)
 {
     node->call<ValueEditor>("Friction", &shape_config->friction, 0.1f, 0.0f, 10.0f);
     node->call<ValueEditor>("Restitution", &shape_config->restitution, 0.1f, 0.0f, 10.0f);
     node->call<ValueEditor>("Density", &shape_config->density, 0.1f, 0.0f, 10.0f);
 }
 
-void ComponentsPanel::draw(WidgetNode *node, BoxCollider2DComponent *collider)
+void ComponentsPanel::draw(WidgetNode* node, BoxCollider2DComponent* collider)
 {
     node->call<Checkbox>("Show collider", &collider->show_collider);
-    draw(node, static_cast<body_shape_config_base_t *>(collider));
+    draw(node, static_cast<body_shape_config_base_t*>(collider));
     node->call<ValueEditor>("Size", &collider->size, 0.1f, 0.0f, 10.0f);
     node->call<ValueEditor>("Center", &collider->center, 0.05f, -10.0f, 10.0f);
     if (float angle = GE::degrees(collider->angle);
@@ -206,10 +206,10 @@ void ComponentsPanel::draw(WidgetNode *node, BoxCollider2DComponent *collider)
     }
 }
 
-void ComponentsPanel::draw(WidgetNode *node, CircleCollider2DComponent *collider)
+void ComponentsPanel::draw(WidgetNode* node, CircleCollider2DComponent* collider)
 {
     node->call<Checkbox>("Show collider", &collider->show_collider);
-    draw(node, static_cast<body_shape_config_base_t *>(collider));
+    draw(node, static_cast<body_shape_config_base_t*>(collider));
     node->call<ValueEditor>("Offset", &collider->offset, 0.05f, -10.0f, 10.0f);
     node->call<ValueEditor>("Radius", &collider->radius, 0.05f, 0.0f, 10.0f);
 }

--- a/apps/level-editor/gui/panels/editor_camera_panel.cpp
+++ b/apps/level-editor/gui/panels/editor_camera_panel.cpp
@@ -40,7 +40,7 @@ using namespace GE::GUI;
 
 namespace LE {
 
-EditorCameraPanel::EditorCameraPanel(GE::Scene::ViewProjectionCamera *camera)
+EditorCameraPanel::EditorCameraPanel(GE::Scene::ViewProjectionCamera* camera)
     : WindowBase{NAME}
     , m_camera{camera}
 {}
@@ -54,7 +54,7 @@ void EditorCameraPanel::onRender()
     drawReadOnlyOptions(&node);
 }
 
-void EditorCameraPanel::drawView(WidgetNode *node)
+void EditorCameraPanel::drawView(WidgetNode* node)
 {
     if (auto position = m_camera->position();
         node->call<::ValueEditor>("Position", &position, 0.1f, -100.0f, 100.0f)) {
@@ -67,14 +67,14 @@ void EditorCameraPanel::drawView(WidgetNode *node)
     }
 }
 
-void EditorCameraPanel::drawProjectionCombo(WidgetNode *node)
+void EditorCameraPanel::drawProjectionCombo(WidgetNode* node)
 {
     static const std::vector<std::string> PROJECTIONS = {
         GE::toString(GE::Scene::ViewProjectionCamera::ORTHOGRAPHIC),
         GE::toString(GE::Scene::ViewProjectionCamera::PERSPECTIVE),
     };
 
-    auto current_projection = GE::toString(m_camera->type());
+    auto     current_projection = GE::toString(m_camera->type());
     ComboBox combo{"Projection type", PROJECTIONS, current_projection};
     node->subNode(&combo);
 
@@ -83,7 +83,7 @@ void EditorCameraPanel::drawProjectionCombo(WidgetNode *node)
     }
 }
 
-void EditorCameraPanel::drawPerspectiveProjection(WidgetNode *node)
+void EditorCameraPanel::drawPerspectiveProjection(WidgetNode* node)
 {
     auto [fov, near, far] = m_camera->perspectiveOptions();
     node->call<::ValueEditor>("Field of view", &fov, 0.1f, 0.0f, 180.0f);
@@ -93,7 +93,7 @@ void EditorCameraPanel::drawPerspectiveProjection(WidgetNode *node)
     m_camera->setPerspectiveOptions({.fov = fov, .near = near, .far = far});
 }
 
-void EditorCameraPanel::drawOrthoProjection(WidgetNode *node)
+void EditorCameraPanel::drawOrthoProjection(WidgetNode* node)
 {
     auto [size, near, far] = m_camera->orthographicOptions();
     node->call<::ValueEditor>("Size", &size, 0.1f, 0.0f, 10.0f);
@@ -103,7 +103,7 @@ void EditorCameraPanel::drawOrthoProjection(WidgetNode *node)
     m_camera->setOrthoOptions({.size = size, .near = near, .far = far});
 }
 
-void EditorCameraPanel::drawProjectionOptions(WidgetNode *node)
+void EditorCameraPanel::drawProjectionOptions(WidgetNode* node)
 {
     switch (m_camera->type()) {
         case GE::Scene::ViewProjectionCamera::PERSPECTIVE: drawPerspectiveProjection(node); break;
@@ -112,7 +112,7 @@ void EditorCameraPanel::drawProjectionOptions(WidgetNode *node)
     }
 }
 
-void EditorCameraPanel::drawReadOnlyOptions(WidgetNode *node)
+void EditorCameraPanel::drawReadOnlyOptions(WidgetNode* node)
 {
     node->call<::Text>("Direction: %s", GE::toString(m_camera->direction()).c_str());
 }

--- a/apps/level-editor/gui/panels/log_panel.cpp
+++ b/apps/level-editor/gui/panels/log_panel.cpp
@@ -96,7 +96,7 @@ public:
     }
 
 private:
-    void sink_it_(const spdlog::details::log_msg &msg) override
+    void sink_it_(const spdlog::details::log_msg& msg) override
     {
         spdlog::memory_buf_t formatted;
         formatter_->format(msg, formatted);
@@ -106,7 +106,7 @@ private:
     void flush_() override {};
 
     mutable std::mutex m_lines_mtx;
-    LogBuffer m_lines;
+    LogBuffer          m_lines;
 };
 
 LogPanel::LogPanel()
@@ -132,14 +132,14 @@ void LogPanel::onRender()
     }
 }
 
-void LogPanel::drawControls(WidgetNode *node)
+void LogPanel::drawControls(WidgetNode* node)
 {
     if (node->call<Button>("Clear")) {
         m_log_sink->clear();
     }
     node->call<SameLine>();
 
-    auto level_string = toString(m_log_sink->level());
+    auto     level_string = toString(m_log_sink->level());
     ComboBox level{"level", LEVELS, level_string};
     node->subNode(&level);
 
@@ -148,7 +148,7 @@ void LogPanel::drawControls(WidgetNode *node)
     }
 }
 
-void LogPanel::drawLogs(WidgetNode *node)
+void LogPanel::drawLogs(WidgetNode* node)
 {
     auto logs = m_log_sink->lines();
     auto log_lines = GE::joinString(logs.begin(), logs.end());

--- a/apps/level-editor/gui/panels/scene_panel.cpp
+++ b/apps/level-editor/gui/panels/scene_panel.cpp
@@ -127,7 +127,7 @@ void ScenePanel::drawEntity(WidgetNode* node, const Entity& entity)
     }
 
     std::string_view tag = entity.get<TagComponent>().tag;
-    auto entity_tree_node = node->makeSubNode<TreeNode>(tag, flags);
+    auto             entity_tree_node = node->makeSubNode<TreeNode>(tag, flags);
 
     if (auto popup_context = WidgetNode::create<PopupContextItem>();
         popup_context.call<MenuItem>(GE_FMTSTR("Remove '{}'", tag))) {
@@ -152,7 +152,7 @@ void ScenePanel::drawEntityDragDrop(const Entity& entity)
     constexpr std::string_view PAYLOAD_TYPE{"entity_payload"};
     constexpr std::string_view POPUP_ID{"scene_panel_entity_drop_popup"};
 
-    auto entity_handle = entity.nativeHandle();
+    auto        entity_handle = entity.nativeHandle();
     const auto& tag = entity.get<TagComponent>();
 
     DragDropPayload drag_drop_paylaod{PAYLOAD_TYPE.data(), &entity_handle};
@@ -189,7 +189,7 @@ void ScenePanel::drawContextMenu(WidgetNode* node)
     constexpr std::string_view POPUP_ID{"empty_space_popup"};
 
     EntityFactory entity_factory{m_ctx->scene(), m_ctx->assets()};
-    auto flags = PopupFlag::MOUSE_BUTTON_RIGHT | PopupFlag::NO_OPEN_OVER_EXISTING_POPUP |
+    auto          flags = PopupFlag::MOUSE_BUTTON_RIGHT | PopupFlag::NO_OPEN_OVER_EXISTING_POPUP |
                  PopupFlag::NO_OPEN_OVER_ITEMS;
 
     auto context_menu_node = node->makeSubNode<PopupContextWindow>(POPUP_ID, flags);

--- a/apps/level-editor/gui/panels/scene_panel.h
+++ b/apps/level-editor/gui/panels/scene_panel.h
@@ -85,10 +85,10 @@ private:
 
     void resetDragDropEntities();
 
-    LevelEditorContext* m_ctx{nullptr};
+    LevelEditorContext*        m_ctx{nullptr};
     DeferredScenePanelCommands m_commands;
 
-    bool m_is_select_entity_handled{false};
+    bool              m_is_select_entity_handled{false};
     GE::Scene::Entity m_drag_drop_src_entity;
     GE::Scene::Entity m_drag_drop_dst_entity;
 };

--- a/apps/level-editor/gui/panels/viewport_panel.cpp
+++ b/apps/level-editor/gui/panels/viewport_panel.cpp
@@ -109,10 +109,10 @@ void ViewportPanel::drawGizmos(GE::Scene::Entity* entity)
     const auto& projection = camera->projection();
 
     auto& tc = entity->get<GE::Scene::TransformComponent>();
-    auto parent_transform = GE::Scene::parentTransform(*entity);
-    auto transform_matrix = parent_transform * tc.transform();
-    bool is_ortho = camera->type() == GE::Scene::ProjectionCamera::ORTHOGRAPHIC;
-    auto position = m_window.position() + m_window.contentRegionMin();
+    auto  parent_transform = GE::Scene::parentTransform(*entity);
+    auto  transform_matrix = parent_transform * tc.transform();
+    bool  is_ortho = camera->type() == GE::Scene::ProjectionCamera::ORTHOGRAPHIC;
+    auto  position = m_window.position() + m_window.contentRegionMin();
 
     Gizmos gizmos{position, m_viewport, is_ortho};
     gizmos.draw(view, projection, Gizmos::TRANSLATE, Gizmos::LOCAL, &transform_matrix);

--- a/apps/level-editor/gui/panels/viewport_panel.h
+++ b/apps/level-editor/gui/panels/viewport_panel.h
@@ -75,12 +75,12 @@ private:
 
     bool onMouseButtonReleased(const GE::MouseButtonReleasedEvent& event);
 
-    LevelEditorContext* m_ctx{nullptr};
-    GE::Vec2 m_viewport{0.0f, 0.0f};
+    LevelEditorContext*   m_ctx{nullptr};
+    GE::Vec2              m_viewport{0.0f, 0.0f};
     ViewportChangedSignal m_viewport_changed_signal;
 
-    bool m_is_focused{false};
-    bool m_is_hovered{false};
+    bool     m_is_focused{false};
+    bool     m_is_hovered{false};
     GE::Vec2 m_mouse_position{0.0f, 0.0f};
 };
 

--- a/apps/level-editor/gui/toolbar/toolbar.cpp
+++ b/apps/level-editor/gui/toolbar/toolbar.cpp
@@ -168,8 +168,8 @@ void Toolbar::onRender()
     button_hovered.w = 0.5f;
     button_active.w = 0.5f;
 
-    StyleVar window_padding_style{StyleVar::WINDOW_PADDING, GE::Vec2{0.0f, 2.0f}};
-    StyleVar item_inner_spacing_style{StyleVar::ITEM_INNER_SPACING, GE::Vec2{0.0f, 0.0f}};
+    StyleVar   window_padding_style{StyleVar::WINDOW_PADDING, GE::Vec2{0.0f, 2.0f}};
+    StyleVar   item_inner_spacing_style{StyleVar::ITEM_INNER_SPACING, GE::Vec2{0.0f, 0.0f}};
     StyleColor button_color{StyleColor::BUTTON, GE::Vec4{0.0f, 0.0f, 0.0f, 0.0f}};
     StyleColor button_hovered_style{StyleColor::BUTTON_HOVERED, button_hovered};
     StyleColor button_active_style{StyleColor::BUTTON_ACTIVE, button_active};

--- a/apps/level-editor/gui/toolbar/toolbar.h
+++ b/apps/level-editor/gui/toolbar/toolbar.h
@@ -79,8 +79,8 @@ private:
     void renderResumeButton(GE::GUI::WidgetNode* node);
     void renderStopButton(GE::GUI::WidgetNode* node);
 
-    LevelEditorContext* m_ctx{nullptr};
-    RenderState m_render_state{nullptr};
+    LevelEditorContext*        m_ctx{nullptr};
+    RenderState                m_render_state{nullptr};
     GE::Scene::ExecutorFactory m_factory;
 
     GE::Shared<GE::Texture> m_play_button_icon;

--- a/apps/level-editor/gui/windows/add_resource_window_base.cpp
+++ b/apps/level-editor/gui/windows/add_resource_window_base.cpp
@@ -46,7 +46,7 @@ namespace {
 
 std::vector<std::string_view> getPackageNames(LevelEditorContext* ctx)
 {
-    auto packages = ctx->assets()->allPackages();
+    auto                          packages = ctx->assets()->allPackages();
     std::vector<std::string_view> package_names(packages.size());
     std::ranges::transform(packages, package_names.begin(),
                            [](const auto* package) { return std::string_view{package->name()}; });

--- a/apps/level-editor/gui/windows/add_resource_window_base.h
+++ b/apps/level-editor/gui/windows/add_resource_window_base.h
@@ -57,8 +57,8 @@ protected:
     void renderPackageCombobox(GE::GUI::WidgetNode* node);
 
     LevelEditorContext* m_ctx{nullptr};
-    std::string m_package_name;
-    std::string m_resource_name;
+    std::string         m_package_name;
+    std::string         m_resource_name;
 
     ErrorSignal m_error_signal;
 };

--- a/apps/level-editor/level_editor.cpp
+++ b/apps/level-editor/level_editor.cpp
@@ -119,8 +119,8 @@ bool LevelEditor::createFramebuffer()
 
 void LevelEditor::createSceneRenderer()
 {
-    auto* renderer = m_ctx.sceneFbo()->renderer();
-    auto* assets = m_ctx.assets();
+    auto*       renderer = m_ctx.sceneFbo()->renderer();
+    auto*       assets = m_ctx.assets();
     const auto* camera = m_ctx.cameraController()->camera().get();
 
     m_ctx.sceneRenderer() =
@@ -129,8 +129,8 @@ void LevelEditor::createSceneRenderer()
 
 void LevelEditor::createEntityPicker()
 {
-    auto* scene = m_ctx.scene();
-    auto* assets = m_ctx.assets();
+    auto*       scene = m_ctx.scene();
+    auto*       assets = m_ctx.assets();
     const auto* camera = m_ctx.cameraController()->camera().get();
 
     m_ctx.entityPicker() = GE::makeScoped<GE::Scene::EntityPicker>(scene, *assets, camera);

--- a/apps/level-editor/level_editor.h
+++ b/apps/level-editor/level_editor.h
@@ -86,7 +86,7 @@ private:
     void onLoadProject();
     void onSaveProject();
 
-    LevelEditorContext m_ctx;
+    LevelEditorContext         m_ctx;
     GE::Scoped<LevelEditorGUI> m_gui;
 
     GE::Vec2 m_viewport{1.0f, 1.0f};

--- a/apps/level-editor/level_editor_context.h
+++ b/apps/level-editor/level_editor_context.h
@@ -70,16 +70,16 @@ public:
     void resetSelectedEntity() { m_selected_entity = {}; }
 
 private:
-    GE::Scoped<Settings> m_settings{GE::makeScoped<Settings>()};
-    GE::Scoped<GE::Framebuffer> m_scene_fbo;
-    GE::Scoped<GE::Scene::IRenderer> m_scene_renderer;
+    GE::Scoped<Settings>                m_settings{GE::makeScoped<Settings>()};
+    GE::Scoped<GE::Framebuffer>         m_scene_fbo;
+    GE::Scoped<GE::Scene::IRenderer>    m_scene_renderer;
     GE::Scoped<GE::Scene::EntityPicker> m_entity_picker;
 
-    GE::Scoped<GE::P2D::World> m_world;
-    GE::Assets::Registry m_assets;
-    GE::Scene::Scene m_scene;
-    GE::Scene::VPCameraController m_camera_controller;
-    GE::Scene::Entity m_selected_entity;
+    GE::Scoped<GE::P2D::World>       m_world;
+    GE::Assets::Registry             m_assets;
+    GE::Scene::Scene                 m_scene;
+    GE::Scene::VPCameraController    m_camera_controller;
+    GE::Scene::Entity                m_selected_entity;
     GE::Scoped<GE::Scene::IExecutor> m_scene_executor{GE::makeScoped<GE::Scene::DummyExecutor>()};
 };
 

--- a/apps/level-editor/level_editor_layer.cpp
+++ b/apps/level-editor/level_editor_layer.cpp
@@ -49,7 +49,7 @@ void LevelEditorLayer::onUpdate(GE::Timestamp ts)
     m_editor.onUpdate(ts);
 }
 
-void LevelEditorLayer::onEvent(GE::Event *event)
+void LevelEditorLayer::onEvent(GE::Event* event)
 {
     BaseLayer::onEvent(event);
     m_editor.onEvent(event);

--- a/apps/level-editor/main.cpp
+++ b/apps/level-editor/main.cpp
@@ -53,14 +53,14 @@ Options:
 )";
 
 struct args_t {
-    bool show_help{false};
+    bool        show_help{false};
     std::string config;
 };
 
 std::optional<args_t> parseArgs(int argc, char** argv)
 {
     std::map<std::string, docopt::value> parsed_args;
-    args_t args{};
+    args_t                               args{};
 
     try {
         parsed_args = docopt::docopt_parse(USAGE, {argv + 1, argv + argc}, true, false);

--- a/apps/level-editor/options.cpp
+++ b/apps/level-editor/options.cpp
@@ -118,7 +118,7 @@ std::optional<GE::Application::settings_t> Options::load(std::string_view option
         return {};
     }
 
-    nlohmann::json json;
+    nlohmann::json              json;
     GE::Application::settings_t settings;
 
     try {

--- a/apps/level-editor/settings/settings.h
+++ b/apps/level-editor/settings/settings.h
@@ -63,9 +63,9 @@ public:
     ProjectSettings& createProject(const std::string& name);
 
 private:
-    AppSettings m_app_settings;
+    AppSettings     m_app_settings;
     ProjectSettings m_current_project;
-    ProjectPaths m_projects;
+    ProjectPaths    m_projects;
 };
 
 } // namespace LE

--- a/apps/level-editor/settings/settings_deserializer.cpp
+++ b/apps/level-editor/settings/settings_deserializer.cpp
@@ -41,7 +41,7 @@
 namespace LE {
 namespace {
 
-bool validate(const YAML::Node &node)
+bool validate(const YAML::Node& node)
 {
     if (auto project = node["projects"]; !project || !project.IsMap()) {
         GE_ERR("Failed to load a settings config file: 'projects' node is not a map");
@@ -58,17 +58,17 @@ bool validate(const YAML::Node &node)
 
 } // namespace
 
-SettingsDeserializer::SettingsDeserializer(Settings *settings)
+SettingsDeserializer::SettingsDeserializer(Settings* settings)
     : m_settings{settings}
 {}
 
-bool SettingsDeserializer::deserialize(const std::string &filepath)
+bool SettingsDeserializer::deserialize(const std::string& filepath)
 {
     YAML::Node node;
 
     try {
         node = YAML::LoadFile(filepath);
-    } catch (const std::exception &e) {
+    } catch (const std::exception& e) {
         GE_CORE_ERR("Failed to load a settings config file from the '{}': {}", filepath, e.what());
         return false;
     }
@@ -79,13 +79,13 @@ bool SettingsDeserializer::deserialize(const std::string &filepath)
 
     try {
         m_settings->setAppSettings(node["app_settings"].as<AppSettings>());
-    } catch (const std::exception &e) {
+    } catch (const std::exception& e) {
         GE_WARN("Failed to load app settings: {}", e.what());
     }
 
     try {
         m_settings->setProjectPaths(node["projects"].as<Settings::ProjectPaths>());
-    } catch (const std::exception &e) {
+    } catch (const std::exception& e) {
         GE_WARN("Failed to load projects settings: {}", e.what());
     }
 
@@ -94,7 +94,7 @@ bool SettingsDeserializer::deserialize(const std::string &filepath)
             !current_project.empty()) {
             return m_settings->setCurrentProject(current_project);
         }
-    } catch (const std::exception &e) {
+    } catch (const std::exception& e) {
         GE_WARN("Failed to current project settings: {}", e.what());
     }
 

--- a/apps/level-editor/settings/settings_serializer.cpp
+++ b/apps/level-editor/settings/settings_serializer.cpp
@@ -41,17 +41,17 @@
 
 namespace LE {
 
-SettingsSerializer::SettingsSerializer(Settings *settings)
+SettingsSerializer::SettingsSerializer(Settings* settings)
     : m_settings{settings}
 {}
 
-bool SettingsSerializer::serialize(const std::string &filepath)
+bool SettingsSerializer::serialize(const std::string& filepath)
 {
     YAML::Node yaml_settings;
     return serializeSettings(&yaml_settings) && writeSettings(yaml_settings, filepath);
 }
 
-bool SettingsSerializer::serializeSettings(YAML::Node *node)
+bool SettingsSerializer::serializeSettings(YAML::Node* node)
 {
     (*node)["app_settings"] = m_settings->appSettings();
     (*node)["current_project"] = m_settings->currentProject()->name();
@@ -59,7 +59,7 @@ bool SettingsSerializer::serializeSettings(YAML::Node *node)
     return true;
 }
 
-bool SettingsSerializer::writeSettings(const YAML::Node &node, const std::string &filepath)
+bool SettingsSerializer::writeSettings(const YAML::Node& node, const std::string& filepath)
 {
     std::ofstream fout{filepath};
 

--- a/examples/sandbox/drawable/cube.cpp
+++ b/examples/sandbox/drawable/cube.cpp
@@ -34,7 +34,7 @@
 
 namespace GE::Examples {
 
-Cube::Cube(Renderer *renderer)
+Cube::Cube(Renderer* renderer)
     : Shape(renderer)
 {
     static const std::vector<vertex_t> VERTICES = {

--- a/examples/sandbox/drawable/drawable.cpp
+++ b/examples/sandbox/drawable/drawable.cpp
@@ -39,8 +39,9 @@ namespace GE::Examples {
 
 Drawable::~Drawable() = default;
 
-Drawable::Drawable(Renderer *renderer, const std::string &vert_shader,
-                   const std::string &frag_shader)
+Drawable::Drawable(Renderer*          renderer,
+                   const std::string& vert_shader,
+                   const std::string& frag_shader)
 {
     auto vert = Shader::create(Shader::Type::VERTEX);
     GE_ASSERT(vert->compileFromFile(vert_shader), "Failed to compile vertex shader");
@@ -58,7 +59,7 @@ Drawable::Drawable(Renderer *renderer, const std::string &vert_shader,
     m_mpv = UniformBuffer::create(sizeof(mvp_t), nullptr);
 }
 
-void Drawable::bind(Renderer *renderer, const mvp_t &mvp)
+void Drawable::bind(Renderer* renderer, const mvp_t& mvp)
 {
     m_mpv->setData(sizeof(mvp_t), &mvp);
 

--- a/examples/sandbox/drawable/drawable.h
+++ b/examples/sandbox/drawable/drawable.h
@@ -61,7 +61,7 @@ protected:
     Drawable(Renderer* renderer, const std::string& vert_shader, const std::string& frag_shader);
     void bind(Renderer* renderer, const mvp_t& mvp);
 
-    Scoped<Pipeline> m_pipeline;
+    Scoped<Pipeline>      m_pipeline;
     Scoped<UniformBuffer> m_mpv;
 };
 

--- a/examples/sandbox/drawable/model.h
+++ b/examples/sandbox/drawable/model.h
@@ -50,7 +50,7 @@ public:
     void draw(Renderer* renderer, const mvp_t& mvp) override;
 
 private:
-    Mesh m_mesh;
+    Mesh            m_mesh;
     Scoped<Texture> m_texture;
 };
 

--- a/examples/sandbox/drawable/shape.h
+++ b/examples/sandbox/drawable/shape.h
@@ -58,7 +58,7 @@ protected:
 
 private:
     Scoped<VertexBuffer> m_vbo;
-    Scoped<IndexBuffer> m_ibo;
+    Scoped<IndexBuffer>  m_ibo;
 };
 
 } // namespace GE::Examples

--- a/examples/sandbox/gui_layer/gui_layer.cpp
+++ b/examples/sandbox/gui_layer/gui_layer.cpp
@@ -59,7 +59,7 @@ void drawView(GE::GUI::WidgetNode* node, const GE::Shared<GE::Scene::ViewProject
     }
 }
 
-void drawProjectionCombo(GE::GUI::WidgetNode* node,
+void drawProjectionCombo(GE::GUI::WidgetNode*                               node,
                          const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     static const std::vector<std::string> PROJECTIONS = {
@@ -67,7 +67,7 @@ void drawProjectionCombo(GE::GUI::WidgetNode* node,
         GE::toString(GE::Scene::ViewProjectionCamera::PERSPECTIVE),
     };
 
-    auto current_projection = GE::toString(camera->type());
+    auto              current_projection = GE::toString(camera->type());
     GE::GUI::ComboBox combo{"Projection type", PROJECTIONS, current_projection};
     node->subNode(&combo);
 
@@ -76,7 +76,7 @@ void drawProjectionCombo(GE::GUI::WidgetNode* node,
     }
 }
 
-void drawPerspectiveProjection(GE::GUI::WidgetNode* node,
+void drawPerspectiveProjection(GE::GUI::WidgetNode*                               node,
                                const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     auto [fov, near, far] = camera->perspectiveOptions();
@@ -87,7 +87,7 @@ void drawPerspectiveProjection(GE::GUI::WidgetNode* node,
     camera->setPerspectiveOptions({.fov = fov, .near = near, .far = far});
 }
 
-void drawOrthoProjection(GE::GUI::WidgetNode* node,
+void drawOrthoProjection(GE::GUI::WidgetNode*                               node,
                          const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     auto [size, near, far] = camera->orthographicOptions();
@@ -98,7 +98,7 @@ void drawOrthoProjection(GE::GUI::WidgetNode* node,
     camera->setOrthoOptions({.size = size, .near = near, .far = far});
 }
 
-void drawProjectionOptions(GE::GUI::WidgetNode* node,
+void drawProjectionOptions(GE::GUI::WidgetNode*                               node,
                            const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     switch (camera->type()) {
@@ -111,7 +111,7 @@ void drawProjectionOptions(GE::GUI::WidgetNode* node,
     }
 }
 
-void drawReadOnlyOptions(GE::GUI::WidgetNode* node,
+void drawReadOnlyOptions(GE::GUI::WidgetNode*                               node,
                          const GE::Shared<GE::Scene::ViewProjectionCamera>& camera)
 {
     node->call<GE::GUI::Text>("Direction: %s", GE::toString(camera->direction()).c_str());
@@ -175,7 +175,7 @@ void GUILayer::onRender()
 
 void GUILayer::drawCheckboxWindow()
 {
-    GUI::Window window{"Windows Checkbox"};
+    GUI::Window     window{"Windows Checkbox"};
     GUI::WidgetNode node{&window};
 
     for (auto& gui_window : m_gui_windows) {

--- a/examples/sandbox/gui_layer/gui_layer_window.cpp
+++ b/examples/sandbox/gui_layer/gui_layer_window.cpp
@@ -63,7 +63,7 @@ void GuiLayerWindow::draw()
         return;
     }
 
-    GUI::StyleVar padding{GUI::StyleVar::WINDOW_PADDING, {0.0f, 0.0f}};
+    GUI::StyleVar   padding{GUI::StyleVar::WINDOW_PADDING, {0.0f, 0.0f}};
     GUI::WidgetNode node{&m_window};
     node.call(&GuiLayerWindow::updateWindowParameters, this);
 

--- a/examples/sandbox/gui_layer/gui_layer_window.h
+++ b/examples/sandbox/gui_layer/gui_layer_window.h
@@ -61,7 +61,7 @@ public:
     template<typename T, typename... Args>
     static Scoped<GuiLayerWindow> create(const std::string& name, Args&&... args)
     {
-        auto window = Scoped<GuiLayerWindow>(new GuiLayerWindow{name});
+        auto  window = Scoped<GuiLayerWindow>(new GuiLayerWindow{name});
         auto* renderer = window->m_fbo->renderer();
         window->m_draw_object = makeScoped<T>(renderer, std::forward<Args>(args)...);
         return window;
@@ -72,16 +72,16 @@ private:
 
     void updateWindowParameters();
 
-    bool m_is_open{false};
-    bool m_is_focused{false};
+    bool        m_is_open{false};
+    bool        m_is_focused{false};
     std::string m_name;
     GUI::Window m_window{m_name, &m_is_open};
 
     Scoped<Framebuffer> m_fbo;
-    Scoped<Drawable> m_draw_object;
+    Scoped<Drawable>    m_draw_object;
 
     Shared<Scene::ViewProjectionCamera> m_camera;
-    Scoped<Scene::VPCameraController> m_camera_controller;
+    Scoped<Scene::VPCameraController>   m_camera_controller;
 };
 
 } // namespace GE::Examples

--- a/examples/sandbox/sandbox.cpp
+++ b/examples/sandbox/sandbox.cpp
@@ -63,13 +63,13 @@ Options:
 
 constexpr GE::Logger::Level LOG_LEVEL{GE::Logger::Level::TRACE};
 constexpr GE::Graphics::API RENDER_API{GE::Graphics::API::VULKAN};
-constexpr auto APP_NAME = "Sandbox";
-constexpr uint8_t MSAA_SAMPLES{4};
+constexpr auto              APP_NAME = "Sandbox";
+constexpr uint8_t           MSAA_SAMPLES{4};
 
 args_t parseArgs(int argc, char** argv)
 {
     std::map<std::string, docopt::value> parsed_args;
-    args_t args{};
+    args_t                               args{};
 
     try {
         parsed_args = docopt::docopt_parse(USAGE, {argv + 1, argv + argc}, true, false);

--- a/examples/sandbox/triangle_layer.cpp
+++ b/examples/sandbox/triangle_layer.cpp
@@ -110,7 +110,7 @@ void TriangleLayer::onDetached()
 
 void TriangleLayer::onUpdate([[maybe_unused]] Timestamp ts) {}
 
-void TriangleLayer::onEvent([[maybe_unused]] Event *event) {}
+void TriangleLayer::onEvent([[maybe_unused]] Event* event) {}
 
 void TriangleLayer::onRender()
 {

--- a/examples/sandbox/triangle_layer.h
+++ b/examples/sandbox/triangle_layer.h
@@ -49,11 +49,11 @@ public:
     void onDetached() override;
 
     void onUpdate(Timestamp ts) override;
-    void onEvent(Event *event) override;
+    void onEvent(Event* event) override;
     void onRender() override;
 
 private:
-    Scoped<Pipeline> m_pipeline;
+    Scoped<Pipeline>     m_pipeline;
     Scoped<VertexBuffer> m_vbo;
 };
 

--- a/examples/sdl2-vulkan/sdl2_vulkan_example.cpp
+++ b/examples/sdl2-vulkan/sdl2_vulkan_example.cpp
@@ -101,8 +101,8 @@ constexpr int ALIGN_16{16};
 
 struct swap_chain_support_details_t {
     VkSurfaceCapabilitiesKHR capabilities{};
-    SurfFormatVector formats;
-    PresentModeVactor present_mode;
+    SurfFormatVector         formats;
+    PresentModeVactor        present_mode;
 };
 
 struct Vertex {
@@ -193,9 +193,11 @@ void printVkPhysicalDevices(const PhysDeviceVector& devices)
     }
 }
 
-VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
-    VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type,
-    const VkDebugUtilsMessengerCallbackDataEXT* callback_data, [[maybe_unused]] void* user_data)
+VKAPI_ATTR VkBool32 VKAPI_CALL
+debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT      severity,
+              VkDebugUtilsMessageTypeFlagsEXT             type,
+              const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
+              [[maybe_unused]] void*                      user_data)
 {
     const char* type_str = "Unknown";
 
@@ -243,16 +245,17 @@ VkResult loadInstanceFuncAndCall(const char* func_name, VkInstance instance, Arg
     return VK_SUCCESS;
 }
 
-VkResult createDebugUtilsMessengerEXT(VkInstance instance,
+VkResult createDebugUtilsMessengerEXT(VkInstance                                instance,
                                       const VkDebugUtilsMessengerCreateInfoEXT* create_info,
-                                      const VkAllocationCallbacks* allocator,
-                                      VkDebugUtilsMessengerEXT* debug_messenger)
+                                      const VkAllocationCallbacks*              allocator,
+                                      VkDebugUtilsMessengerEXT*                 debug_messenger)
 {
     return loadInstanceFuncAndCall<PFN_vkCreateDebugUtilsMessengerEXT>(
         "vkCreateDebugUtilsMessengerEXT", instance, create_info, allocator, debug_messenger);
 }
 
-void destroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT debug_messenger,
+void destroyDebugUtilsMessengerEXT(VkInstance                   instance,
+                                   VkDebugUtilsMessengerEXT     debug_messenger,
                                    const VkAllocationCallbacks* allocator)
 {
     loadInstanceFuncAndCall<PFN_vkDestroyDebugUtilsMessengerEXT>(
@@ -291,9 +294,9 @@ ShaderCodeVector compileShader(const std::string& filename, shaderc_shader_kind 
         return {};
     }
 
-    std::string source(std::istreambuf_iterator<char>{fin}, std::istreambuf_iterator<char>{});
+    std::string       source(std::istreambuf_iterator<char>{fin}, std::istreambuf_iterator<char>{});
     shaderc::Compiler compiler;
-    auto result = compiler.CompileGlslToSpv(source, shader_kind, filename.c_str());
+    auto              result = compiler.CompileGlslToSpv(source, shader_kind, filename.c_str());
 
     if (result.GetCompilationStatus() != shaderc_compilation_status_success) {
         GE_ERR("Failed to compile '{}'", filename);
@@ -423,22 +426,32 @@ private:
     uint32_t findMemoryType(uint32_t type_filter, VkMemoryPropertyFlags properties);
     VkSampleCountFlagBits getMaxUsableSampleCount();
 
-    std::pair<VkBuffer, VkDeviceMemory> createBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
+    std::pair<VkBuffer, VkDeviceMemory> createBuffer(VkDeviceSize          size,
+                                                     VkBufferUsageFlags    usage,
                                                      VkMemoryPropertyFlags properties);
     void copyBuffer(VkBuffer dst, VkBuffer src, VkDeviceSize size);
 
-    std::pair<VkImage, VkDeviceMemory> createImage(glm::uvec2 size, uint32_t mip_levels,
+    std::pair<VkImage, VkDeviceMemory> createImage(glm::uvec2            size,
+                                                   uint32_t              mip_levels,
                                                    VkSampleCountFlagBits num_samples,
-                                                   VkFormat format, VkImageTiling tiling,
-                                                   VkImageUsageFlags usage,
+                                                   VkFormat              format,
+                                                   VkImageTiling         tiling,
+                                                   VkImageUsageFlags     usage,
                                                    VkMemoryPropertyFlags properties);
-    VkImageView createImageView(VkImage image, VkFormat format, VkImageAspectFlags aspect_flags,
-                                uint32_t mip_levels);
-    void transitionImageLayout(VkImage image, VkFormat format, VkImageLayout old_layout,
-                               VkImageLayout new_layout, uint32_t mip_levels);
+    VkImageView createImageView(VkImage            image,
+                                VkFormat           format,
+                                VkImageAspectFlags aspect_flags,
+                                uint32_t           mip_levels);
+    void transitionImageLayout(VkImage       image,
+                               VkFormat      format,
+                               VkImageLayout old_layout,
+                               VkImageLayout new_layout,
+                               uint32_t      mip_levels);
     void copyBufferToImage(VkImage image, VkBuffer buffer, glm::uvec2 size);
-    void createMipmaps(VkImage image, VkFormat image_format, const glm::uvec2& size,
-                       uint32_t mip_levels);
+    void createMipmaps(VkImage           image,
+                       VkFormat          image_format,
+                       const glm::uvec2& size,
+                       uint32_t          mip_levels);
 
     VkExtent2D chooseSwapExtent(const VkSurfaceCapabilitiesKHR& capabilities);
 
@@ -447,70 +460,71 @@ private:
     VkDebugUtilsMessengerCreateInfoEXT getDebugMsgrCreateInfo() const;
     NamesVector getRequiredExtensions();
     swap_chain_support_details_t querySwapChainSupport(VkPhysicalDevice device);
-    VkFormat findSupportedFormat(const FormatVector& candidates, VkImageTiling tiling,
+    VkFormat findSupportedFormat(const FormatVector&  candidates,
+                                 VkImageTiling        tiling,
                                  VkFormatFeatureFlags features);
     VkFormat findDepthFormat();
 
     bool m_is_closed{false};
 
-    SDL_Window* m_window{nullptr};
-    VkInstance m_vk_instance{VK_NULL_HANDLE};
-    VkSurfaceKHR m_surface{VK_NULL_HANDLE};
+    SDL_Window*      m_window{nullptr};
+    VkInstance       m_vk_instance{VK_NULL_HANDLE};
+    VkSurfaceKHR     m_surface{VK_NULL_HANDLE};
     VkPhysicalDevice m_physical_device{VK_NULL_HANDLE};
-    VkDevice m_device{VK_NULL_HANDLE};
-    VkQueue m_graphics_queue{VK_NULL_HANDLE};
-    VkQueue m_present_queue{VK_NULL_HANDLE};
+    VkDevice         m_device{VK_NULL_HANDLE};
+    VkQueue          m_graphics_queue{VK_NULL_HANDLE};
+    VkQueue          m_present_queue{VK_NULL_HANDLE};
 
     VkDebugUtilsMessageSeverityFlagsEXT m_debug_severity{VULKAN_LOG_INFO};
-    VkDebugUtilsMessengerEXT m_debug_messenger{VK_NULL_HANDLE};
+    VkDebugUtilsMessengerEXT            m_debug_messenger{VK_NULL_HANDLE};
 
-    VkSwapchainKHR m_swap_chain{VK_NULL_HANDLE};
-    ImageVector m_swap_chain_images;
-    ImageViewVector m_swap_chain_image_views;
+    VkSwapchainKHR    m_swap_chain{VK_NULL_HANDLE};
+    ImageVector       m_swap_chain_images;
+    ImageViewVector   m_swap_chain_image_views;
     FramebufferVector m_swap_chain_framebuffers;
-    VkFormat m_swap_chain_image_format{};
-    VkExtent2D m_swap_chain_extent{};
+    VkFormat          m_swap_chain_image_format{};
+    VkExtent2D        m_swap_chain_extent{};
 
-    VkRenderPass m_render_pass{VK_NULL_HANDLE};
+    VkRenderPass          m_render_pass{VK_NULL_HANDLE};
     VkDescriptorSetLayout m_descriptor_set_layout{VK_NULL_HANDLE};
-    VkPipelineLayout m_pipeline_layout{VK_NULL_HANDLE};
-    VkPipeline m_graphics_pipeline{VK_NULL_HANDLE};
+    VkPipelineLayout      m_pipeline_layout{VK_NULL_HANDLE};
+    VkPipeline            m_graphics_pipeline{VK_NULL_HANDLE};
 
     VkCommandPool m_command_pool{VK_NULL_HANDLE};
     CmdBuffVector m_command_buffers{VK_NULL_HANDLE};
 
     SemaphoreVector m_image_available_semaphores;
     SemaphoreVector m_render_finished_semaphores;
-    FenceVector m_in_flight_fences;
-    FenceVector m_images_in_flight;
-    size_t m_current_frame{0};
+    FenceVector     m_in_flight_fences;
+    FenceVector     m_images_in_flight;
+    size_t          m_current_frame{0};
 
-    VkBuffer m_vertex_buffer{VK_NULL_HANDLE};
-    VkDeviceMemory m_vertex_buffer_memory{VK_NULL_HANDLE};
-    VkBuffer m_index_buffer{VK_NULL_HANDLE};
-    VkDeviceMemory m_index_buffer_memory{VK_NULL_HANDLE};
-    BufferVector m_uniform_buffers;
-    DeviceMemVector m_uniform_buffers_memory;
-    VkDescriptorPool m_descriptor_pool{VK_NULL_HANDLE};
-    DescSetsVector m_descriptor_sets;
-    std::vector<Vertex> m_vertices;
+    VkBuffer              m_vertex_buffer{VK_NULL_HANDLE};
+    VkDeviceMemory        m_vertex_buffer_memory{VK_NULL_HANDLE};
+    VkBuffer              m_index_buffer{VK_NULL_HANDLE};
+    VkDeviceMemory        m_index_buffer_memory{VK_NULL_HANDLE};
+    BufferVector          m_uniform_buffers;
+    DeviceMemVector       m_uniform_buffers_memory;
+    VkDescriptorPool      m_descriptor_pool{VK_NULL_HANDLE};
+    DescSetsVector        m_descriptor_sets;
+    std::vector<Vertex>   m_vertices;
     std::vector<uint32_t> m_indices;
-    bool m_framebuffer_resized{false};
+    bool                  m_framebuffer_resized{false};
 
-    uint32_t m_mip_levels{};
-    VkImage m_texture_image{VK_NULL_HANDLE};
-    VkDeviceMemory m_texture_image_memory{VK_NULL_HANDLE};
-    VkImageView m_texture_image_view{VK_NULL_HANDLE};
-    VkSampler m_texture_sampler{VK_NULL_HANDLE};
+    uint32_t              m_mip_levels{};
+    VkImage               m_texture_image{VK_NULL_HANDLE};
+    VkDeviceMemory        m_texture_image_memory{VK_NULL_HANDLE};
+    VkImageView           m_texture_image_view{VK_NULL_HANDLE};
+    VkSampler             m_texture_sampler{VK_NULL_HANDLE};
     VkSampleCountFlagBits m_msaa_samples{VK_SAMPLE_COUNT_1_BIT};
 
-    VkImage m_color_image{VK_NULL_HANDLE};
+    VkImage        m_color_image{VK_NULL_HANDLE};
     VkDeviceMemory m_color_image_memory{VK_NULL_HANDLE};
-    VkImageView m_color_image_view{VK_NULL_HANDLE};
+    VkImageView    m_color_image_view{VK_NULL_HANDLE};
 
-    VkImage m_depth_image{VK_NULL_HANDLE};
+    VkImage        m_depth_image{VK_NULL_HANDLE};
     VkDeviceMemory m_depth_image_memory{VK_NULL_HANDLE};
-    VkImageView m_depth_image_view{VK_NULL_HANDLE};
+    VkImageView    m_depth_image_view{VK_NULL_HANDLE};
 
     NamesVector m_validation_layers;
     NamesVector m_device_extensions;
@@ -609,7 +623,7 @@ void HelloTriangleApplication::handleWindowEvents(SDL_WindowEvent event)
 void HelloTriangleApplication::drawFrame()
 {
     static constexpr uint64_t timeout_none = std::numeric_limits<uint64_t>::max();
-    uint32_t image_idx{};
+    uint32_t                  image_idx{};
 
     vkWaitForFences(m_device, 1, &m_in_flight_fences[m_current_frame], VK_TRUE, timeout_none);
 
@@ -706,7 +720,7 @@ void HelloTriangleApplication::recreateSwapChain()
 void HelloTriangleApplication::updateUniformBuffer(uint32_t current_image)
 {
     static auto start_time = std::chrono::steady_clock::now();
-    auto current_time = std::chrono::steady_clock::now();
+    auto        current_time = std::chrono::steady_clock::now();
 
     using Sec = std::chrono::seconds::period;
     float time = std::chrono::duration<float, Sec>(current_time - start_time).count();
@@ -724,7 +738,7 @@ void HelloTriangleApplication::updateUniformBuffer(uint32_t current_image)
     ubo.proj[1][1] *= -1;
 
     static constexpr size_t ubo_size = sizeof(ubo_mvp_t);
-    void* data{nullptr};
+    void*                   data{nullptr};
     vkMapMemory(m_device, m_uniform_buffers_memory[current_image], 0, ubo_size, 0, &data);
     std::memcpy(data, &ubo, ubo_size);
     vkUnmapMemory(m_device, m_uniform_buffers_memory[current_image]);
@@ -852,7 +866,7 @@ void HelloTriangleApplication::createVkInstance()
     app_info.engineVersion = VK_MAKE_VERSION(0, 0, 0);
     app_info.apiVersion = VK_API_VERSION_1_2;
 
-    auto debug_create_info = getDebugMsgrCreateInfo();
+    auto                 debug_create_info = getDebugMsgrCreateInfo();
     VkInstanceCreateInfo create_info{};
     create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     create_info.pApplicationInfo = &app_info;
@@ -922,10 +936,10 @@ void HelloTriangleApplication::pickPhysicalDevice()
 
 void HelloTriangleApplication::createLogicalDevice()
 {
-    auto indices = findQueueFamilies(m_physical_device);
+    auto                                 indices = findQueueFamilies(m_physical_device);
     std::vector<VkDeviceQueueCreateInfo> queue_create_infos;
-    std::set<uint32_t> unique_queue_families = {indices.graphics_family.value(),
-                                                indices.present_family.value()};
+    std::set<uint32_t>                   unique_queue_families = {indices.graphics_family.value(),
+                                                                  indices.present_family.value()};
 
     float queue_priorities{1.0f};
 
@@ -961,10 +975,10 @@ void HelloTriangleApplication::createLogicalDevice()
 
 void HelloTriangleApplication::createSwapChain()
 {
-    auto swap_chain_support = querySwapChainSupport(m_physical_device);
-    auto surface_format = chooseSwapSurfaceFormat(swap_chain_support.formats);
-    auto present_mode = chooseSwapPresentMode(swap_chain_support.present_mode);
-    auto extent = chooseSwapExtent(swap_chain_support.capabilities);
+    auto     swap_chain_support = querySwapChainSupport(m_physical_device);
+    auto     surface_format = chooseSwapSurfaceFormat(swap_chain_support.formats);
+    auto     present_mode = chooseSwapPresentMode(swap_chain_support.present_mode);
+    auto     extent = chooseSwapExtent(swap_chain_support.capabilities);
     uint32_t image_count = swap_chain_support.capabilities.minImageCount + 1;
 
     if (swap_chain_support.capabilities.maxImageCount > 0 &&
@@ -987,7 +1001,7 @@ void HelloTriangleApplication::createSwapChain()
     create_info.clipped = VK_TRUE;
     create_info.oldSwapchain = VK_NULL_HANDLE;
 
-    auto indices = findQueueFamilies(m_physical_device);
+    auto                    indices = findQueueFamilies(m_physical_device);
     std::array<uint32_t, 2> queue_family_indices = {indices.graphics_family.value(),
                                                     indices.present_family.value()};
 
@@ -1277,7 +1291,7 @@ void HelloTriangleApplication::createGraphicsPipeline()
 
 void HelloTriangleApplication::createColorResources()
 {
-    VkFormat color_format = m_swap_chain_image_format;
+    VkFormat          color_format = m_swap_chain_image_format;
     VkImageUsageFlags usage =
         VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
@@ -1341,9 +1355,9 @@ void HelloTriangleApplication::createCommandPool()
 
 void HelloTriangleApplication::createTextureImage()
 {
-    int width{0};
-    int height{0};
-    int channels{0};
+    int      width{0};
+    int      height{0};
+    int      channels{0};
     stbi_uc* pixels =
         stbi_load(VIKING_ROOM_TEXTURE_PATH, &width, &height, &channels, STBI_rgb_alpha);
     VkDeviceSize image_size = width * height * 4;
@@ -1354,7 +1368,7 @@ void HelloTriangleApplication::createTextureImage()
 
     m_mip_levels = static_cast<uint32_t>(std::floor(std::log2(std::max(width, height)))) + 1;
 
-    VkBufferUsageFlags stagig_buffer_usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    VkBufferUsageFlags    stagig_buffer_usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     VkMemoryPropertyFlags staging_buffer_props =
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
@@ -1368,8 +1382,8 @@ void HelloTriangleApplication::createTextureImage()
 
     stbi_image_free(pixels);
 
-    VkFormat format{VK_FORMAT_R8G8B8A8_SRGB};
-    VkImageTiling tiling{VK_IMAGE_TILING_OPTIMAL};
+    VkFormat          format{VK_FORMAT_R8G8B8A8_SRGB};
+    VkImageTiling     tiling{VK_IMAGE_TILING_OPTIMAL};
     VkImageUsageFlags image_usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
                                     VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
@@ -1421,11 +1435,11 @@ void HelloTriangleApplication::createTextureSampler()
 
 void HelloTriangleApplication::loadModel()
 {
-    tinyobj::attrib_t attrib{};
-    std::vector<tinyobj::shape_t> shapes;
+    tinyobj::attrib_t                attrib{};
+    std::vector<tinyobj::shape_t>    shapes;
     std::vector<tinyobj::material_t> materials;
-    std::string warn;
-    std::string err;
+    std::string                      warn;
+    std::string                      err;
 
     if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, VIKING_ROOM_MODEL_PATH)) {
         throw std::runtime_error{warn + err};
@@ -1456,7 +1470,7 @@ void HelloTriangleApplication::loadModel()
 
 void HelloTriangleApplication::createVertexBuffers()
 {
-    VkDeviceSize buffer_size = sizeof(m_vertices[0]) * m_vertices.size();
+    VkDeviceSize          buffer_size = sizeof(m_vertices[0]) * m_vertices.size();
     VkMemoryPropertyFlags staging_buff_props =
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
@@ -1482,7 +1496,7 @@ void HelloTriangleApplication::createVertexBuffers()
 
 void HelloTriangleApplication::createIndexBuffers()
 {
-    VkDeviceSize buffer_size = sizeof(m_indices[0]) * m_indices.size();
+    VkDeviceSize          buffer_size = sizeof(m_indices[0]) * m_indices.size();
     VkMemoryPropertyFlags staging_buff_props =
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
@@ -1620,7 +1634,7 @@ void HelloTriangleApplication::createCommandBuffers()
         }
 
         std::array<VkClearValue, 2> clear_values{};
-        std::array<float, 4> clear_color = {0.0f, 0.0f, 0.0f, 1.0f};
+        std::array<float, 4>        clear_color = {0.0f, 0.0f, 0.0f, 1.0f};
         std::ranges::copy(clear_color, clear_values[0].color.float32);
         clear_values[1].depthStencil = {.depth = 1.0f, .stencil = 0};
 
@@ -1633,7 +1647,7 @@ void HelloTriangleApplication::createCommandBuffers()
         render_pass_info.pClearValues = clear_values.data();
         render_pass_info.clearValueCount = clear_values.size();
 
-        std::array<VkBuffer, 1> vertex_buffers = {m_vertex_buffer};
+        std::array<VkBuffer, 1>     vertex_buffers = {m_vertex_buffer};
         std::array<VkDeviceSize, 1> offsets = {0};
 
         vkCmdBeginRenderPass(m_command_buffers[i], &render_pass_info, VK_SUBPASS_CONTENTS_INLINE);
@@ -1724,7 +1738,7 @@ bool HelloTriangleApplication::isDeviceSuitable(VkPhysicalDevice device)
 
 bool HelloTriangleApplication::checkDeviceExtensionsSupport(VkPhysicalDevice device)
 {
-    auto extension_properties = getDeviceExtensions(device);
+    auto                  extension_properties = getDeviceExtensions(device);
     std::set<std::string> required_extensions{m_device_extensions.begin(),
                                               m_device_extensions.end()};
 
@@ -1765,7 +1779,7 @@ queue_family_indices_t HelloTriangleApplication::findQueueFamilies(VkPhysicalDev
     return indices;
 }
 
-uint32_t HelloTriangleApplication::findMemoryType(uint32_t type_filter,
+uint32_t HelloTriangleApplication::findMemoryType(uint32_t              type_filter,
                                                   VkMemoryPropertyFlags properties)
 {
     VkPhysicalDeviceMemoryProperties mem_properties{};
@@ -1773,8 +1787,8 @@ uint32_t HelloTriangleApplication::findMemoryType(uint32_t type_filter,
 
     for (uint32_t i{0}; i < mem_properties.memoryTypeCount; i++) {
         uint32_t mem_type = 1 << i;
-        bool is_type_suitable = (type_filter & mem_type) != 0;
-        bool is_properties_suitable =
+        bool     is_type_suitable = (type_filter & mem_type) != 0;
+        bool     is_properties_suitable =
             (mem_properties.memoryTypes[i].propertyFlags & properties) != 0;
 
         if (is_type_suitable && is_properties_suitable) {
@@ -1807,10 +1821,11 @@ VkSampleCountFlagBits HelloTriangleApplication::getMaxUsableSampleCount()
 }
 
 std::pair<VkBuffer, VkDeviceMemory>
-HelloTriangleApplication::createBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
+HelloTriangleApplication::createBuffer(VkDeviceSize          size,
+                                       VkBufferUsageFlags    usage,
                                        VkMemoryPropertyFlags properties)
 {
-    VkBuffer buffer{VK_NULL_HANDLE};
+    VkBuffer       buffer{VK_NULL_HANDLE};
     VkDeviceMemory buffer_memory{VK_NULL_HANDLE};
 
     VkBufferCreateInfo buffer_info{};
@@ -1855,11 +1870,16 @@ void HelloTriangleApplication::copyBuffer(VkBuffer dst, VkBuffer src, VkDeviceSi
     endSingleTimeCommand(command_buffer);
 }
 
-std::pair<VkImage, VkDeviceMemory> HelloTriangleApplication::createImage(
-    glm::uvec2 size, uint32_t mip_levels, VkSampleCountFlagBits num_samples, VkFormat format,
-    VkImageTiling tiling, VkImageUsageFlags usage, VkMemoryPropertyFlags properties)
+std::pair<VkImage, VkDeviceMemory>
+HelloTriangleApplication::createImage(glm::uvec2            size,
+                                      uint32_t              mip_levels,
+                                      VkSampleCountFlagBits num_samples,
+                                      VkFormat              format,
+                                      VkImageTiling         tiling,
+                                      VkImageUsageFlags     usage,
+                                      VkMemoryPropertyFlags properties)
 {
-    VkImage image{VK_NULL_HANDLE};
+    VkImage        image{VK_NULL_HANDLE};
     VkDeviceMemory image_memory{VK_NULL_HANDLE};
 
     VkImageCreateInfo image_info{};
@@ -1899,9 +1919,10 @@ std::pair<VkImage, VkDeviceMemory> HelloTriangleApplication::createImage(
     return {image, image_memory};
 }
 
-VkImageView HelloTriangleApplication::createImageView(VkImage image, VkFormat format,
+VkImageView HelloTriangleApplication::createImageView(VkImage            image,
+                                                      VkFormat           format,
                                                       VkImageAspectFlags aspect_flags,
-                                                      uint32_t mip_levels)
+                                                      uint32_t           mip_levels)
 {
     VkImageView image_view{VK_NULL_HANDLE};
 
@@ -1923,9 +1944,11 @@ VkImageView HelloTriangleApplication::createImageView(VkImage image, VkFormat fo
     return image_view;
 }
 
-void HelloTriangleApplication::transitionImageLayout(VkImage image, VkFormat format,
+void HelloTriangleApplication::transitionImageLayout(VkImage       image,
+                                                     VkFormat      format,
                                                      VkImageLayout old_layout,
-                                                     VkImageLayout new_layout, uint32_t mip_levels)
+                                                     VkImageLayout new_layout,
+                                                     uint32_t      mip_levels)
 {
     VkCommandBuffer command_buffer = beginSingleTimeCommand();
 
@@ -2008,8 +2031,10 @@ void HelloTriangleApplication::copyBufferToImage(VkImage image, VkBuffer buffer,
     endSingleTimeCommand(command_buffer);
 }
 
-void HelloTriangleApplication::createMipmaps(VkImage image, VkFormat image_format,
-                                             const glm::uvec2& size, uint32_t mip_levels)
+void HelloTriangleApplication::createMipmaps(VkImage           image,
+                                             VkFormat          image_format,
+                                             const glm::uvec2& size,
+                                             uint32_t          mip_levels)
 {
     VkFormatProperties format_properties{};
     vkGetPhysicalDeviceFormatProperties(m_physical_device, image_format, &format_properties);
@@ -2116,7 +2141,7 @@ VkExtent2D HelloTriangleApplication::chooseSwapExtent(const VkSurfaceCapabilitie
 
 VkShaderModule HelloTriangleApplication::createShaderModule(const ShaderCodeVector& code)
 {
-    VkShaderModule shader_module{VK_NULL_HANDLE};
+    VkShaderModule           shader_module{VK_NULL_HANDLE};
     VkShaderModuleCreateInfo create_info{};
     create_info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
     create_info.pCode = code.data();
@@ -2187,8 +2212,8 @@ HelloTriangleApplication::querySwapChainSupport(VkPhysicalDevice device)
     return details;
 }
 
-VkFormat HelloTriangleApplication::findSupportedFormat(const FormatVector& candidates,
-                                                       VkImageTiling tiling,
+VkFormat HelloTriangleApplication::findSupportedFormat(const FormatVector&  candidates,
+                                                       VkImageTiling        tiling,
                                                        VkFormatFeatureFlags features)
 {
     for (auto format : candidates) {

--- a/include/genesis/app/application.h
+++ b/include/genesis/app/application.h
@@ -52,8 +52,8 @@ class GE_API Application: public EventListener
 {
 public:
     struct settings_t {
-        Log::settings_t log{};
-        Window::settings_t window{};
+        Log::settings_t      log{};
+        Window::settings_t   window{};
         Graphics::settings_t graphics{};
     };
 
@@ -101,12 +101,12 @@ private:
     void renderLayers();
     void clearLayers();
 
-    Shared<Window> m_window;
+    Shared<Window>            m_window;
     std::deque<Shared<Layer>> m_layers;
-    WindowState m_window_state{WindowState::NONE};
+    WindowState               m_window_state{WindowState::NONE};
 
     volatile bool m_running{true};
-    Timestamp m_prev_frame_ts;
+    Timestamp     m_prev_frame_ts;
 };
 
 } // namespace GE

--- a/include/genesis/assets/mesh_resource.h
+++ b/include/genesis/assets/mesh_resource.h
@@ -60,7 +60,7 @@ public:
 private:
     MeshResource(const std::string& package, const config_t& config);
 
-    std::string m_filepath;
+    std::string  m_filepath;
     Shared<Mesh> m_mesh{makeShared<Mesh>()};
 };
 

--- a/include/genesis/assets/package.h
+++ b/include/genesis/assets/package.h
@@ -80,8 +80,8 @@ private:
     std::string m_filepath;
 
     std::unordered_map<std::string, Shared<PipelineResource>> m_pipelines;
-    std::unordered_map<std::string, Shared<MeshResource>> m_meshes;
-    std::unordered_map<std::string, Shared<TextureResource>> m_textures;
+    std::unordered_map<std::string, Shared<MeshResource>>     m_meshes;
+    std::unordered_map<std::string, Shared<TextureResource>>  m_textures;
 };
 
 template<typename T>
@@ -108,7 +108,7 @@ template<typename T>
 std::vector<Shared<T>> Package::getAllOf() const
 {
     std::vector<Shared<T>> resources;
-    auto get_value = [](const auto& item) { return item.second; };
+    auto                   get_value = [](const auto& item) { return item.second; };
 
     if constexpr (T::GROUP == Group::PIPELINES) {
         resources.resize(m_pipelines.size());

--- a/include/genesis/assets/resource_id.h
+++ b/include/genesis/assets/resource_id.h
@@ -79,7 +79,7 @@ private:
     void move(ResourceID& other);
 
     std::string m_package;
-    Group m_group{Group::UNKNOWN};
+    Group       m_group{Group::UNKNOWN};
     std::string m_name;
 };
 

--- a/include/genesis/assets/resource_serializer.h
+++ b/include/genesis/assets/resource_serializer.h
@@ -47,15 +47,15 @@ class TextureResource;
 class GE_API ResourceSerializer
 {
 public:
-    explicit ResourceSerializer(Registry *registry);
+    explicit ResourceSerializer(Registry* registry);
 
-    bool serialize(const std::string &config_filepath);
+    bool serialize(const std::string& config_filepath);
 
 private:
     YAML::Node serializeAssets();
-    YAML::Node serializePackage(const Package &package);
+    YAML::Node serializePackage(const Package& package);
 
-    Registry *m_registry{nullptr};
+    Registry* m_registry{nullptr};
 };
 
 } // namespace GE::Assets

--- a/include/genesis/assets/texture_resource.h
+++ b/include/genesis/assets/texture_resource.h
@@ -60,7 +60,7 @@ public:
 private:
     TextureResource(const std::string& package, const config_t& config);
 
-    std::string m_filepath;
+    std::string     m_filepath;
     Shared<Texture> m_texture;
 };
 

--- a/include/genesis/core/asserts.h
+++ b/include/genesis/core/asserts.h
@@ -36,12 +36,12 @@
 #include <genesis/core/utils.h>
 
 #ifndef GE_DISABLE_ASSERTS
-#define GE_CORE_ASSERT(expr, ...)                  \
-    static_cast<bool>(expr) ? static_cast<void>(0) \
+#define GE_CORE_ASSERT(expr, ...)                                                                  \
+    static_cast<bool>(expr) ? static_cast<void>(0)                                                 \
                             : ::GE::Details::coreAssert(__FILE__, __LINE__, #expr, __VA_ARGS__)
 
-#define GE_ASSERT(expr, ...)                       \
-    static_cast<bool>(expr) ? static_cast<void>(0) \
+#define GE_ASSERT(expr, ...)                                                                       \
+    static_cast<bool>(expr) ? static_cast<void>(0)                                                 \
                             : ::GE::Details::clientAssert(__FILE__, __LINE__, #expr, __VA_ARGS__)
 
 namespace GE::Details {

--- a/include/genesis/core/enum.h
+++ b/include/genesis/core/enum.h
@@ -35,13 +35,13 @@
 #include <fmt/format.h>
 #include <magic_enum/magic_enum.hpp>
 
-#define GE_EXTEND_ENUM_RANGE(enum_type, min_value, max_value)  \
-    namespace magic_enum::customize {                          \
-    template<>                                                 \
-    struct enum_range<enum_type> {                             \
-        static constexpr int min{static_cast<int>(min_value)}; \
-        static constexpr int max{static_cast<int>(max_value)}; \
-    };                                                         \
+#define GE_EXTEND_ENUM_RANGE(enum_type, min_value, max_value)                                      \
+    namespace magic_enum::customize {                                                              \
+    template<>                                                                                     \
+    struct enum_range<enum_type> {                                                                 \
+        static constexpr int min{static_cast<int>(min_value)};                                     \
+        static constexpr int max{static_cast<int>(max_value)};                                     \
+    };                                                                                             \
     } // namespace magic_enum::customize
 
 namespace GE {

--- a/include/genesis/core/log.h
+++ b/include/genesis/core/log.h
@@ -116,7 +116,10 @@ public:
 
 private:
     template<typename... Args>
-    void log(spdlog::level::level_enum level, const char* file, int line, std::string_view fmt,
+    void log(spdlog::level::level_enum level,
+             const char*               file,
+             int                       line,
+             std::string_view          fmt,
              Args&&... args)
     {
         if (m_logger) {
@@ -125,8 +128,8 @@ private:
         }
     }
 
-    std::string m_logger_name;
-    Level m_level{Level::INFO};
+    std::string                     m_logger_name;
+    Level                           m_level{Level::INFO};
     std::shared_ptr<spdlog::logger> m_logger;
 };
 

--- a/include/genesis/core/string_utils.h
+++ b/include/genesis/core/string_utils.h
@@ -42,7 +42,7 @@ template<typename ForwardIt>
 std::string joinString(ForwardIt begin, ForwardIt end, std::string_view delimiter = {})
 {
     std::string result;
-    auto it = begin;
+    auto        it = begin;
 
     if (it != end) {
         result += std::string{*it};

--- a/include/genesis/core/utils.h
+++ b/include/genesis/core/utils.h
@@ -51,7 +51,7 @@
 #endif
 
 // Bind member function
-#define GE_EVENT_MEM_FN(mem_func) \
+#define GE_EVENT_MEM_FN(mem_func)                                                                  \
     [this](auto&&... args) { return mem_func(std::forward<decltype(args)>(args)...); }
 
 // Concat names
@@ -72,8 +72,9 @@ auto toEventHandler(Func&& f, Type* instance)
 }
 
 template<typename Key, typename Value>
-Value getValue(const std::unordered_map<Key, Value>& map, const Key& key,
-               const Value& default_value = {})
+Value getValue(const std::unordered_map<Key, Value>& map,
+               const Key&                            key,
+               const Value&                          default_value = {})
 {
     if (auto it = map.find(key); it != map.end()) {
         return it->second;

--- a/include/genesis/graphics/framebuffer.h
+++ b/include/genesis/graphics/framebuffer.h
@@ -56,20 +56,20 @@ struct fb_attachment_t {
         DEPTH_STENCIL
     };
 
-    Type type{Type::UNKNOWN};
-    TextureType texture_type{TextureType::UNKNOWN};
-    TextureFormat texture_format{TextureFormat::UNKNOWN};
+    Type           type{Type::UNKNOWN};
+    TextureType    texture_type{TextureType::UNKNOWN};
+    TextureFormat  texture_format{TextureFormat::UNKNOWN};
     ClearColorType clear_color{Vec4{1.0f, 1.0f, 1.0f, 1.0f}};
-    float clear_depth{1.0f};
+    float          clear_depth{1.0f};
 };
 
 class GE_API Framebuffer: public NonCopyable
 {
 public:
     struct config_t {
-        Vec2 size{1920.0f, 1080.0f};
-        uint32_t layers{1};
-        uint32_t msaa_samples{1};
+        Vec2                         size{1920.0f, 1080.0f};
+        uint32_t                     layers{1};
+        uint32_t                     msaa_samples{1};
         std::vector<fb_attachment_t> attachments = {
             {.type = fb_attachment_t::Type::COLOR,
              .texture_type = TextureType::TEXTURE_2D,

--- a/include/genesis/graphics/graphics.h
+++ b/include/genesis/graphics/graphics.h
@@ -49,9 +49,9 @@ public:
     };
 
     struct settings_t {
-        API api{API_DEFAULT};
+        API         api{API_DEFAULT};
         std::string app_name;
-        uint8_t msaa_samples{1};
+        uint8_t     msaa_samples{1};
 
         static constexpr API API_DEFAULT{API::VULKAN};
     };
@@ -78,7 +78,7 @@ private:
         return &instance;
     }
 
-    API m_api{API::NONE};
+    API                     m_api{API::NONE};
     Scoped<GraphicsContext> m_context;
 };
 

--- a/include/genesis/graphics/graphics_context.h
+++ b/include/genesis/graphics/graphics_context.h
@@ -49,9 +49,9 @@ class GE_API GraphicsContext: public Interface
 {
 public:
     struct config_t {
-        void* window{nullptr};
+        void*            window{nullptr};
         std::string_view app_name;
-        uint8_t msaa_samples{1};
+        uint8_t          msaa_samples{1};
     };
 
     struct limits_t {

--- a/include/genesis/graphics/graphics_factory.h
+++ b/include/genesis/graphics/graphics_factory.h
@@ -53,7 +53,7 @@ public:
     virtual Scoped<Framebuffer> createFramebuffer(const Framebuffer::config_t& config) const = 0;
 
     virtual Scoped<IndexBuffer> createIndexBuffer(const uint32_t* indices,
-                                                  uint32_t count) const = 0;
+                                                  uint32_t        count) const = 0;
     virtual Scoped<VertexBuffer> createVertexBuffer(uint32_t size, const void* vertices) const = 0;
     virtual Scoped<StagingBuffer> createStagingBuffer() const = 0;
     virtual Scoped<UniformBuffer> createUniformBuffer(uint32_t size, const void* data) const = 0;

--- a/include/genesis/graphics/mesh.h
+++ b/include/genesis/graphics/mesh.h
@@ -64,7 +64,7 @@ private:
     bool populateBuffers(const tinyobj::ObjReader& reader);
 
     Scoped<VertexBuffer> m_vbo;
-    Scoped<IndexBuffer> m_ibo;
+    Scoped<IndexBuffer>  m_ibo;
 };
 
 } // namespace GE

--- a/include/genesis/graphics/pipeline.h
+++ b/include/genesis/graphics/pipeline.h
@@ -48,7 +48,8 @@ public:
     using NativeHandle = void*;
 
     virtual void bind(GPUCommandQueue* queue) = 0;
-    virtual void bind(GPUCommandQueue* queue, const std::string& name,
+    virtual void bind(GPUCommandQueue*     queue,
+                      const std::string&   name,
                       const UniformBuffer& ubo) = 0;
     virtual void bind(GPUCommandQueue* queue, const std::string& name, const Texture& texture) = 0;
 
@@ -57,14 +58,18 @@ public:
     virtual void pushConstant(GPUCommandQueue* queue, const std::string& name, uint32_t value) = 0;
     virtual void pushConstant(GPUCommandQueue* queue, const std::string& name, float value) = 0;
     virtual void pushConstant(GPUCommandQueue* queue, const std::string& name, double value) = 0;
-    virtual void pushConstant(GPUCommandQueue* queue, const std::string& name,
-                              const Vec2& value) = 0;
-    virtual void pushConstant(GPUCommandQueue* queue, const std::string& name,
-                              const Vec3& value) = 0;
-    virtual void pushConstant(GPUCommandQueue* queue, const std::string& name,
-                              const Vec4& value) = 0;
-    virtual void pushConstant(GPUCommandQueue* queue, const std::string& name,
-                              const Mat4& value) = 0;
+    virtual void pushConstant(GPUCommandQueue*   queue,
+                              const std::string& name,
+                              const Vec2&        value) = 0;
+    virtual void pushConstant(GPUCommandQueue*   queue,
+                              const std::string& name,
+                              const Vec3&        value) = 0;
+    virtual void pushConstant(GPUCommandQueue*   queue,
+                              const std::string& name,
+                              const Vec4&        value) = 0;
+    virtual void pushConstant(GPUCommandQueue*   queue,
+                              const std::string& name,
+                              const Mat4&        value) = 0;
 
     virtual NativeHandle nativeHandle() const = 0;
 };

--- a/include/genesis/graphics/pipeline_config.h
+++ b/include/genesis/graphics/pipeline_config.h
@@ -95,23 +95,23 @@ struct GE_API blending_t {
 
     BlendFactor src_color_factor{BlendFactor::SRC_ALPHA};
     BlendFactor dst_color_factor{BlendFactor::ONE_MINUS_SRC_ALPHA};
-    BlendOp color_op{BlendOp::ADD};
+    BlendOp     color_op{BlendOp::ADD};
 
     BlendFactor src_alpha_factor{BlendFactor::SRC_ALPHA};
     BlendFactor dst_alpha_factor{BlendFactor::ONE_MINUS_SRC_ALPHA};
-    BlendOp alpha_op{BlendOp::ADD};
+    BlendOp     alpha_op{BlendOp::ADD};
 };
 
 struct pipeline_config_t {
     using BlendingConfig = std::variant<blending_t, std::vector<blending_t>>;
 
-    Shared<Shader> vertex_shader{Shader::create(Shader::Type::VERTEX)};
-    Shared<Shader> fragment_shader{Shader::create(Shader::Type::FRAGMENT)};
-    BlendingConfig blending{blending_t{.enabled = false}};
+    Shared<Shader>    vertex_shader{Shader::create(Shader::Type::VERTEX)};
+    Shared<Shader>    fragment_shader{Shader::create(Shader::Type::FRAGMENT)};
+    BlendingConfig    blending{blending_t{.enabled = false}};
     PrimitiveTopology primitive_topology{PrimitiveTopology::TRIANGLE_LIST};
-    PolygonMode polygon_mode{PolygonMode::FILL};
-    bool depth_test_enable{true};
-    bool depth_write_enable{true};
+    PolygonMode       polygon_mode{PolygonMode::FILL};
+    bool              depth_test_enable{true};
+    bool              depth_write_enable{true};
 };
 
 } // namespace GE

--- a/include/genesis/graphics/primitives_renderer.h
+++ b/include/genesis/graphics/primitives_renderer.h
@@ -56,8 +56,8 @@ public:
     void renderSquare(const Mat4& transform, const Vec4& color);
 
 private:
-    Renderer* m_renderer{nullptr};
-    Scoped<Pipeline> m_pipeline;
+    Renderer*            m_renderer{nullptr};
+    Scoped<Pipeline>     m_pipeline;
     Scoped<VertexBuffer> m_circle_vbo;
     Scoped<VertexBuffer> m_square_vbo;
 };

--- a/include/genesis/graphics/render_command.h
+++ b/include/genesis/graphics/render_command.h
@@ -67,13 +67,15 @@ public:
     void draw(VertexBuffer* buffer, uint32_t vertex_count);
     void draw(VertexBuffer* vbo, IndexBuffer* ibo);
     void draw(GUI::Context* gui_layer);
-    void draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_vertex,
+    void draw(uint32_t vertex_count,
+              uint32_t instance_count,
+              uint32_t first_vertex,
               uint32_t first_instance);
 
     void submit(GPUCommandBuffer cmd);
 
 private:
-    Renderer* m_renderer{nullptr};
+    Renderer*       m_renderer{nullptr};
     GPUCommandQueue m_cmd_queue;
 };
 

--- a/include/genesis/graphics/renderer.h
+++ b/include/genesis/graphics/renderer.h
@@ -55,8 +55,11 @@ public:
         CLEAR_ALL
     };
 
-    virtual void draw(GPUCommandQueue* queue, uint32_t vertex_count, uint32_t instance_count,
-                      uint32_t first_vertex, uint32_t first_instance) = 0;
+    virtual void draw(GPUCommandQueue* queue,
+                      uint32_t         vertex_count,
+                      uint32_t         instance_count,
+                      uint32_t         first_vertex,
+                      uint32_t         first_instance) = 0;
 
     virtual bool beginFrame(ClearMode clear_mode = CLEAR_ALL) = 0;
     virtual void endFrame() = 0;

--- a/include/genesis/graphics/shader_input_layout.h
+++ b/include/genesis/graphics/shader_input_layout.h
@@ -49,13 +49,13 @@ struct shader_attribute_t {
         DOUBLE
     };
 
-    BaseType base_type{BaseType::NONE};
+    BaseType    base_type{BaseType::NONE};
     std::string name;
-    uint32_t location{};
-    uint32_t size{0};
-    uint32_t vec_size{0};
-    uint32_t vec_column{0};
-    uint32_t offset{0};
+    uint32_t    location{};
+    uint32_t    size{0};
+    uint32_t    vec_size{0};
+    uint32_t    vec_column{0};
+    uint32_t    offset{0};
 
     uint32_t fullSize() const { return size * vec_size * vec_column; }
 };
@@ -80,7 +80,7 @@ public:
 
 private:
     std::deque<shader_attribute_t> m_attributes;
-    uint32_t m_stride{0};
+    uint32_t                       m_stride{0};
 };
 
 } // namespace GE

--- a/include/genesis/graphics/shader_precompiler.h
+++ b/include/genesis/graphics/shader_precompiler.h
@@ -41,15 +41,16 @@ namespace GE {
 class GE_API ShaderPrecompiler
 {
 public:
-    static ShaderCache compileFromFile(Shader::Type shader_type, const std::string &filepath);
-    static ShaderCache compileFromSource(Shader::Type shader_type, const std::string &source_code);
+    static ShaderCache compileFromFile(Shader::Type shader_type, const std::string& filepath);
+    static ShaderCache compileFromSource(Shader::Type shader_type, const std::string& source_code);
 
-    static ShaderCache loadShaderCache(const std::string &filepath);
-    static bool saveShaderCache(const ShaderCache &shader_cache, const std::string &filepath);
+    static ShaderCache loadShaderCache(const std::string& filepath);
+    static bool saveShaderCache(const ShaderCache& shader_cache, const std::string& filepath);
 
 private:
-    static ShaderCache compileShader(Shader::Type type, const std::string &source_code,
-                                     const std::string &filepath);
+    static ShaderCache compileShader(Shader::Type       type,
+                                     const std::string& source_code,
+                                     const std::string& filepath);
 };
 
 } // namespace GE

--- a/include/genesis/graphics/shader_reflection.h
+++ b/include/genesis/graphics/shader_reflection.h
@@ -43,7 +43,7 @@ namespace GE {
 class GE_API ShaderReflection
 {
 public:
-    explicit ShaderReflection(const std::vector<uint32_t> &shader_cache);
+    explicit ShaderReflection(const std::vector<uint32_t>& shader_cache);
     ~ShaderReflection();
 
     ShaderInputLayout inputLayout() const;

--- a/include/genesis/graphics/shader_resource_descriptors.h
+++ b/include/genesis/graphics/shader_resource_descriptors.h
@@ -49,17 +49,17 @@ struct GE_API resource_descriptor_t {
     };
 
     std::string name;
-    Type type{UNKNOWN};
-    uint32_t set{0};
-    uint32_t binding{0};
-    uint32_t count{0};
+    Type        type{UNKNOWN};
+    uint32_t    set{0};
+    uint32_t    binding{0};
+    uint32_t    count{0};
 };
 
 struct GE_API push_constant_t {
     std::string name;
-    uint32_t offset{0};
-    uint32_t size{0};
-    uint32_t pipeline_stages{0};
+    uint32_t    offset{0};
+    uint32_t    size{0};
+    uint32_t    pipeline_stages{0};
 };
 
 constexpr bool operator==(const resource_descriptor_t& lhs, const resource_descriptor_t& rhs)

--- a/include/genesis/graphics/texture.h
+++ b/include/genesis/graphics/texture.h
@@ -88,20 +88,20 @@ enum class TextureWrap : uint8_t
 };
 
 struct texture_config_t {
-    TextureType type{TextureType::UNKNOWN};
+    TextureType   type{TextureType::UNKNOWN};
     TextureFormat format{TextureFormat::SRGB8};
-    uint32_t width{1};
-    uint32_t height{1};
-    uint8_t depth{1};
-    uint8_t layers{1};
+    uint32_t      width{1};
+    uint32_t      height{1};
+    uint8_t       depth{1};
+    uint8_t       layers{1};
     TextureFilter min_filter{TextureFilter::LINEAR_MIPMAP_LINEAR};
     TextureFilter mag_filter{TextureFilter::LINEAR};
-    TextureWrap wrap_u{TextureWrap::REPEAT};
-    TextureWrap wrap_v{TextureWrap::REPEAT};
-    TextureWrap wrap_w{TextureWrap::REPEAT};
-    uint32_t mip_levels{MIP_LEVELS_AUTO};
-    bool image_storage{false};
-    bool is_opaque{true};
+    TextureWrap   wrap_u{TextureWrap::REPEAT};
+    TextureWrap   wrap_v{TextureWrap::REPEAT};
+    TextureWrap   wrap_w{TextureWrap::REPEAT};
+    uint32_t      mip_levels{MIP_LEVELS_AUTO};
+    bool          image_storage{false};
+    bool          is_opaque{true};
 
     static constexpr uint32_t MIP_LEVELS_AUTO{0};
 };

--- a/include/genesis/gui/file_dialog.h
+++ b/include/genesis/gui/file_dialog.h
@@ -70,10 +70,10 @@ public:
 private:
     void error(std::string_view error);
 
-    SingleResultSignal m_single_result_file;
+    SingleResultSignal    m_single_result_file;
     MultipleResultsSignal m_multiple_files_signal;
-    CancelSignal m_cancel_signal;
-    ErrorSignal m_error_signal;
+    CancelSignal          m_cancel_signal;
+    ErrorSignal           m_error_signal;
 };
 
 GE_API std::string openSingleFile(std::string_view filters);

--- a/include/genesis/gui/gizmos/gizmos.h
+++ b/include/genesis/gui/gizmos/gizmos.h
@@ -55,8 +55,12 @@ public:
 
     Gizmos(const Vec2& window_pos, const Vec2& window_size, bool is_ortho = false);
 
-    void draw(const Mat4& view, const Mat4& projection, Operation operation, Mode mode,
-              Mat4* matrix, float* snap = nullptr);
+    void draw(const Mat4& view,
+              const Mat4& projection,
+              Operation   operation,
+              Mode        mode,
+              Mat4*       matrix,
+              float*      snap = nullptr);
 
     bool isOver() const;
     bool isUsing() const;

--- a/include/genesis/gui/widgets/button.h
+++ b/include/genesis/gui/widgets/button.h
@@ -49,10 +49,13 @@ class ImageButton
 {
 public:
     ImageButton() = delete;
-    static bool call(std::string_view str_id, void* texture_id, const Vec2& image_size,
-                     const Vec2& uv0 = {0.0f, 0.0f}, const Vec2& uv1 = {1.0f, 1.0f},
-                     const Vec4& bg_col = Vec4{0.0f, 0.0f, 0.0f, 0.0f},
-                     const Vec4& tint_col = Vec4{1.0f, 1.0f, 1.0f, 1.0f});
+    static bool call(std::string_view str_id,
+                     void*            texture_id,
+                     const Vec2&      image_size,
+                     const Vec2&      uv0 = {0.0f, 0.0f},
+                     const Vec2&      uv1 = {1.0f, 1.0f},
+                     const Vec4&      bg_col = Vec4{0.0f, 0.0f, 0.0f, 0.0f},
+                     const Vec4&      tint_col = Vec4{1.0f, 1.0f, 1.0f, 1.0f});
 };
 
 } // namespace GE::GUI

--- a/include/genesis/gui/widgets/combo_box.h
+++ b/include/genesis/gui/widgets/combo_box.h
@@ -59,8 +59,10 @@ public:
     };
 
     template<typename Items>
-    ComboBox(std::string_view name, const Items& items, std::string_view current_item,
-             Flags flags = NONE)
+    ComboBox(std::string_view name,
+             const Items&     items,
+             std::string_view current_item,
+             Flags            flags = NONE)
         : ComboBox(name, {items.begin(), items.end()}, current_item, flags)
     {}
 
@@ -69,7 +71,7 @@ public:
     std::string_view selectedItem() const { return m_selected_item; }
 
 private:
-    Items m_items;
+    Items            m_items;
     std::string_view m_current_item;
     std::string_view m_selected_item;
 };

--- a/include/genesis/gui/widgets/drag_drop.h
+++ b/include/genesis/gui/widgets/drag_drop.h
@@ -82,10 +82,10 @@ private:
     bool acceptPaylaod();
     bool validateAcceptedPayload(size_t requested_size) const;
 
-    Flags m_flags{NONE};
+    Flags       m_flags{NONE};
     std::string m_payload_type;
     const void* m_payload_data{nullptr};
-    size_t m_paylaod_size{0};
+    size_t      m_paylaod_size{0};
 
     std::vector<uint8_t> m_accepted_payload;
 };
@@ -106,8 +106,9 @@ public:
         AUTO_EXPIRE_PAYLOAD = bit<uint8_t>(5),
     };
 
-    DragDropSource(const DragDropPayload& payload, std::string_view dragging_text,
-                   Flags flags = NONE);
+    DragDropSource(const DragDropPayload& payload,
+                   std::string_view       dragging_text,
+                   Flags                  flags = NONE);
 };
 
 class GE_API DragDropTarget: public Widget

--- a/include/genesis/gui/widgets/image.h
+++ b/include/genesis/gui/widgets/image.h
@@ -41,7 +41,9 @@ class Image
 public:
     using NativeID = void*;
 
-    static void call(NativeID image_id, const Vec2& size, const Vec2& uv0 = {0.0f, 1.0f},
+    static void call(NativeID    image_id,
+                     const Vec2& size,
+                     const Vec2& uv0 = {0.0f, 1.0f},
                      const Vec2& uv1 = {1.0f, 0.0f},
                      const Vec4& tint_col = {1.0f, 1.0f, 1.0f, 1.0f},
                      const Vec4& border_col = {0.0f, 0.0f, 0.0f, 0.0f});

--- a/include/genesis/gui/widgets/menu_item.h
+++ b/include/genesis/gui/widgets/menu_item.h
@@ -39,10 +39,12 @@ namespace GE::GUI {
 class MenuItem
 {
 public:
-    static bool call(std::string_view label, std::string_view shortcut = {}, bool selected = false,
-                     bool enabled = true);
-    static bool call(std::string_view label, std::string_view shortcut, bool* selected,
-                     bool enabled = true);
+    static bool call(std::string_view label,
+                     std::string_view shortcut = {},
+                     bool             selected = false,
+                     bool             enabled = true);
+    static bool
+    call(std::string_view label, std::string_view shortcut, bool* selected, bool enabled = true);
 };
 
 } // namespace GE::GUI

--- a/include/genesis/gui/widgets/popup.h
+++ b/include/genesis/gui/widgets/popup.h
@@ -61,14 +61,14 @@ class GE_API PopupContextWindow: public Widget
 {
 public:
     explicit PopupContextWindow(std::string_view str_id = {},
-                                PopupFlags flags = PopupFlag::MOUSE_BUTTON_RIGHT);
+                                PopupFlags       flags = PopupFlag::MOUSE_BUTTON_RIGHT);
 };
 
 class GE_API PopupContextItem: public Widget
 {
 public:
     explicit PopupContextItem(std::string_view str_id = {},
-                              PopupFlags flags = PopupFlag::MOUSE_BUTTON_RIGHT);
+                              PopupFlags       flags = PopupFlag::MOUSE_BUTTON_RIGHT);
 };
 
 class GE_API Popup: public Widget

--- a/include/genesis/gui/widgets/value_editor.h
+++ b/include/genesis/gui/widgets/value_editor.h
@@ -43,12 +43,27 @@ class ValueEditor
 public:
     using Flags = int;
 
-    static bool call(std::string_view label, Vec2* value, float v_speed = 1.0f, float v_min = 0.0f,
-                     float v_max = 1.0f, std::string_view format = "%.3f", Flags flags = 0);
-    static bool call(std::string_view label, Vec3* value, float v_speed = 1.0f, float v_min = 0.0f,
-                     float v_max = 1.0f, std::string_view format = "%.3f", Flags flags = 0);
-    static bool call(std::string_view label, float* value, float v_speed = 1.0f, float v_min = 0.0f,
-                     float v_max = 1.0f, std::string_view format = "%.3f", Flags flags = 0);
+    static bool call(std::string_view label,
+                     Vec2*            value,
+                     float            v_speed = 1.0f,
+                     float            v_min = 0.0f,
+                     float            v_max = 1.0f,
+                     std::string_view format = "%.3f",
+                     Flags            flags = 0);
+    static bool call(std::string_view label,
+                     Vec3*            value,
+                     float            v_speed = 1.0f,
+                     float            v_min = 0.0f,
+                     float            v_max = 1.0f,
+                     std::string_view format = "%.3f",
+                     Flags            flags = 0);
+    static bool call(std::string_view label,
+                     float*           value,
+                     float            v_speed = 1.0f,
+                     float            v_min = 0.0f,
+                     float            v_max = 1.0f,
+                     std::string_view format = "%.3f",
+                     Flags            flags = 0);
 };
 
 } // namespace GE::GUI

--- a/include/genesis/gui/widgets/widget.h
+++ b/include/genesis/gui/widgets/widget.h
@@ -77,7 +77,7 @@ protected:
 
 private:
     BeginFunc m_begin{nullptr};
-    EndFunc m_end{nullptr};
+    EndFunc   m_end{nullptr};
 
     bool m_is_opened{false};
     bool m_force_end{false};

--- a/include/genesis/gui/widgets/widget_node.h
+++ b/include/genesis/gui/widgets/widget_node.h
@@ -144,7 +144,7 @@ private:
     }
 
     Scoped<Widget> m_internal_widget;
-    Widget* m_widget{nullptr};
+    Widget*        m_widget{nullptr};
 };
 
 } // namespace GE::GUI

--- a/include/genesis/gui/window/modal_windows.h
+++ b/include/genesis/gui/window/modal_windows.h
@@ -53,14 +53,14 @@ public:
 
 private:
     std::list<Scoped<WindowBase>> m_modals;
-    int m_id{0};
+    int                           m_id{0};
 };
 
 template<typename T, typename... Args>
 T* ModalWindows::open(const std::string& name, Args&&... args)
 {
-    auto unique_name = GE_FMTSTR("{}##{}", name, m_id++);
-    auto window = makeScoped<T>(unique_name, std::forward<Args>(args)...);
+    auto  unique_name = GE_FMTSTR("{}##{}", name, m_id++);
+    auto  window = makeScoped<T>(unique_name, std::forward<Args>(args)...);
     auto* modal = window.get();
 
     m_modals.push_back(std::move(window));

--- a/include/genesis/gui/window/window_base.h
+++ b/include/genesis/gui/window/window_base.h
@@ -42,15 +42,16 @@ namespace GE::GUI {
 class GE_API WindowBase: public IWindow
 {
 public:
-    explicit WindowBase(std::string_view name, Window::Flags flags = Window::NONE,
-                        bool is_open = false)
+    explicit WindowBase(std::string_view name,
+                        Window::Flags    flags = Window::NONE,
+                        bool             is_open = false)
         : m_name{name}
         , m_is_open{is_open}
         , m_window{m_name, &m_is_open, flags}
     {}
 
     void onUpdate([[maybe_unused]] Timestamp ts) override {}
-    void onEvent([[maybe_unused]] Event *event) override {}
+    void onEvent([[maybe_unused]] Event* event) override {}
 
     void open() override { m_is_open = true; }
     void close() override { m_is_open = false; }
@@ -61,7 +62,7 @@ public:
 
 private:
     std::string m_name;
-    bool m_is_open{false};
+    bool        m_is_open{false};
 
 protected:
     Window m_window;

--- a/include/genesis/math/transform.h
+++ b/include/genesis/math/transform.h
@@ -45,13 +45,15 @@ using glm::rotate;
 using glm::scale;
 using glm::translate;
 
-inline Mat4 makeTransform3D(const Vec3& translation, const Vec3& rotation,
+inline Mat4 makeTransform3D(const Vec3& translation,
+                            const Vec3& rotation,
                             const Vec3& scale = Vec3{1.0f})
 {
     return GE::translate(Mat4{1.0f}, translation) * toMat4(Quat{rotation}) * GE::scale(scale);
 }
 
-inline Mat4 makeTransform2D(const Vec2& translation, float rotation_z,
+inline Mat4 makeTransform2D(const Vec2& translation,
+                            float       rotation_z,
                             const Vec2& scale = Vec2{1.0f, 1.0f})
 {
     return makeTransform3D(Vec3{translation, 0.0f}, Vec3{0.0f, 0.0f, rotation_z},

--- a/include/genesis/physics2d/rigid_body_shape.h
+++ b/include/genesis/physics2d/rigid_body_shape.h
@@ -43,13 +43,13 @@ struct body_shape_config_base_t {
 };
 
 struct box_body_shape_config_t: body_shape_config_base_t {
-    Vec2 size{1.0f, 1.0f};
-    Vec2 center{0.0f, 0.0f};
+    Vec2  size{1.0f, 1.0f};
+    Vec2  center{0.0f, 0.0f};
     float angle{0.0f};
 };
 
 struct circle_body_shape_config_t: body_shape_config_base_t {
-    Vec2 offset{0.0f, 0.0f};
+    Vec2  offset{0.0f, 0.0f};
     float radius{0.5f};
 };
 

--- a/include/genesis/physics2d/world.h
+++ b/include/genesis/physics2d/world.h
@@ -45,8 +45,9 @@ class World: public NonCopyable
 public:
     virtual void step(Timestamp ts, int32_t sub_step_count) = 0;
 
-    virtual Scoped<RigidBody> createRigidBody(RigidBody::Type type, const Vec2& position,
-                                              float angle) = 0;
+    virtual Scoped<RigidBody> createRigidBody(RigidBody::Type type,
+                                              const Vec2&     position,
+                                              float           angle) = 0;
 
     static Scoped<World> create(const Vec2& gravity);
 };

--- a/include/genesis/scene/camera/projection_camera.h
+++ b/include/genesis/scene/camera/projection_camera.h
@@ -87,8 +87,8 @@ private:
 
     float aspectRatio() const;
 
-    Type m_type{Type::ORTHOGRAPHIC};
-    ortho_options_t m_ortho_options;
+    Type                  m_type{Type::ORTHOGRAPHIC};
+    ortho_options_t       m_ortho_options;
     perspective_options_t m_perspective_options;
 
     Mat4 m_projection{1.0f};

--- a/include/genesis/scene/camera/vp_camera_controller.h
+++ b/include/genesis/scene/camera/vp_camera_controller.h
@@ -89,8 +89,8 @@ private:
     void zoom(float delta);
 
     Shared<VPCamera> m_camera;
-    Mode m_mode{MODE_NONE};
-    Vec2 m_mouse_offset{0.0f};
+    Mode             m_mode{MODE_NONE};
+    Vec2             m_mouse_offset{0.0f};
 };
 
 } // namespace GE::Scene

--- a/include/genesis/scene/camera/yaml_convert.h
+++ b/include/genesis/scene/camera/yaml_convert.h
@@ -59,7 +59,7 @@ struct convert<GE::Scene::ProjectionCamera::Type> {
 
 template<>
 struct convert<GE::Scene::ProjectionCamera::ortho_options_t> {
-    static bool decode(const Node& node,
+    static bool decode(const Node&                                   node,
                        GE::Scene::ProjectionCamera::ortho_options_t& ortho_options)
     {
         ortho_options = {
@@ -84,7 +84,7 @@ struct convert<GE::Scene::ProjectionCamera::ortho_options_t> {
 
 template<>
 struct convert<GE::Scene::ProjectionCamera::perspective_options_t> {
-    static bool decode(const Node& node,
+    static bool decode(const Node&                                         node,
                        GE::Scene::ProjectionCamera::perspective_options_t& perspective_options)
     {
         perspective_options = {

--- a/include/genesis/scene/component_list.h
+++ b/include/genesis/scene/component_list.h
@@ -37,8 +37,13 @@
 
 namespace GE::Scene {
 
-using ComponentList =
-    TypeList<CameraComponent, TagComponent, TransformComponent, SpriteComponent, MaterialComponent,
-             RigidBody2DComponent, BoxCollider2DComponent, CircleCollider2DComponent>;
+using ComponentList = TypeList<CameraComponent,
+                               TagComponent,
+                               TransformComponent,
+                               SpriteComponent,
+                               MaterialComponent,
+                               RigidBody2DComponent,
+                               BoxCollider2DComponent,
+                               CircleCollider2DComponent>;
 
 } // namespace GE::Scene

--- a/include/genesis/scene/components/camera_component.h
+++ b/include/genesis/scene/components/camera_component.h
@@ -38,7 +38,7 @@ namespace GE::Scene {
 
 struct CameraComponent {
     ProjectionCamera camera;
-    bool fixed_aspect_ratio{false};
+    bool             fixed_aspect_ratio{false};
 
     static constexpr std::string_view NAME{"Camera"};
 };

--- a/include/genesis/scene/components/physics2d_components.h
+++ b/include/genesis/scene/components/physics2d_components.h
@@ -41,7 +41,7 @@ namespace GE::Scene {
 
 struct RigidBody2DComponent {
     P2D::RigidBody::Type body_type{P2D::RigidBody::Type::STATIC};
-    bool fixed_rotation{false};
+    bool                 fixed_rotation{false};
 
     Scoped<P2D::RigidBody> body;
 

--- a/include/genesis/scene/components/sprite_component.h
+++ b/include/genesis/scene/components/sprite_component.h
@@ -40,31 +40,31 @@ namespace GE::Scene {
 
 struct GE_API SpriteComponent {
     Shared<Texture> texture;
-    Shared<Mesh> mesh;
-    Vec3 color{0.0f, 0.0f, 0.0f};
+    Shared<Mesh>    mesh;
+    Vec3            color{0.0f, 0.0f, 0.0f};
 
     static constexpr std::string_view NAME{"Sprite"};
 
     bool isValid() const { return texture && mesh; }
 
-    const Assets::ResourceID &textureID() const { return m_texture_id; }
-    const Assets::ResourceID &meshID() const { return m_mesh_id; }
+    const Assets::ResourceID& textureID() const { return m_texture_id; }
+    const Assets::ResourceID& meshID() const { return m_mesh_id; }
 
     void setTextureID(Assets::ResourceID id) { m_texture_id = std::move(id); }
     void setMeshID(Assets::ResourceID id) { m_mesh_id = std::move(id); }
 
-    bool loadTexture(Assets::Registry *assets);
-    bool loadMesh(Assets::Registry *assets);
-    bool loadAll(Assets::Registry *assets);
+    bool loadTexture(Assets::Registry* assets);
+    bool loadMesh(Assets::Registry* assets);
+    bool loadAll(Assets::Registry* assets);
 
 private:
     Assets::ResourceID m_texture_id;
     Assets::ResourceID m_mesh_id;
 };
 
-inline bool SpriteComponent::loadTexture(Assets::Registry *assets)
+inline bool SpriteComponent::loadTexture(Assets::Registry* assets)
 {
-    if (const auto &resource = assets->get<Assets::TextureResource>(m_texture_id);
+    if (const auto& resource = assets->get<Assets::TextureResource>(m_texture_id);
         resource != nullptr) {
         texture = resource->texture();
         return true;
@@ -73,9 +73,9 @@ inline bool SpriteComponent::loadTexture(Assets::Registry *assets)
     return false;
 }
 
-inline bool SpriteComponent::loadMesh(Assets::Registry *assets)
+inline bool SpriteComponent::loadMesh(Assets::Registry* assets)
 {
-    if (const auto &resource = assets->get<Assets::MeshResource>(m_mesh_id); resource != nullptr) {
+    if (const auto& resource = assets->get<Assets::MeshResource>(m_mesh_id); resource != nullptr) {
         mesh = resource->mesh();
         return true;
     }
@@ -83,7 +83,7 @@ inline bool SpriteComponent::loadMesh(Assets::Registry *assets)
     return false;
 }
 
-inline bool SpriteComponent::loadAll(Assets::Registry *assets)
+inline bool SpriteComponent::loadAll(Assets::Registry* assets)
 {
     return loadTexture(assets) && loadMesh(assets);
 }

--- a/include/genesis/scene/entity.h
+++ b/include/genesis/scene/entity.h
@@ -97,7 +97,7 @@ private:
     Entity(NativeHandle native_handle, entt::registry* registry);
     Entity makeEntity(NativeHandle entity_handle) const { return {entity_handle, m_registry}; }
 
-    NativeHandle m_handle{NULL_ID};
+    NativeHandle    m_handle{NULL_ID};
     entt::registry* m_registry{nullptr};
 };
 

--- a/include/genesis/scene/entity_factory.h
+++ b/include/genesis/scene/entity_factory.h
@@ -58,7 +58,7 @@ public:
 private:
     void appendToTail(const Entity& entity);
 
-    Scene* m_scene{nullptr};
+    Scene*            m_scene{nullptr};
     Assets::Registry* m_assets{nullptr};
 };
 

--- a/include/genesis/scene/entity_picker.h
+++ b/include/genesis/scene/entity_picker.h
@@ -72,12 +72,12 @@ private:
 
     void renderEntityId(const Entity& entity);
 
-    Scene* m_scene{nullptr};
+    Scene*                      m_scene{nullptr};
     const ViewProjectionCamera* m_camera{nullptr};
-    Scoped<Framebuffer> m_entity_id_fbo;
-    Scoped<Pipeline> m_entity_id_pipeline;
-    Scoped<StagingBuffer> m_entity_id_buffer;
-    bool m_is_buffer_updated{false};
+    Scoped<Framebuffer>         m_entity_id_fbo;
+    Scoped<Pipeline>            m_entity_id_pipeline;
+    Scoped<StagingBuffer>       m_entity_id_buffer;
+    bool                        m_is_buffer_updated{false};
 };
 
 } // namespace GE::Scene

--- a/include/genesis/scene/executor/executor_factory.h
+++ b/include/genesis/scene/executor/executor_factory.h
@@ -64,10 +64,10 @@ public:
 private:
     using FactoryMethod = std::function<Scoped<IExecutor>()>;
 
-    Scene* m_scene{nullptr};
-    Assets::Registry* m_assets{nullptr};
-    P2D::World* m_world{nullptr};
-    std::string m_saved_scene_path;
+    Scene*                                              m_scene{nullptr};
+    Assets::Registry*                                   m_assets{nullptr};
+    P2D::World*                                         m_world{nullptr};
+    std::string                                         m_saved_scene_path;
     std::unordered_map<std::string_view, FactoryMethod> m_factory_methods;
 };
 

--- a/include/genesis/scene/executor/runtime2d_executor.h
+++ b/include/genesis/scene/executor/runtime2d_executor.h
@@ -63,9 +63,9 @@ private:
     void initializePhysics2D();
     void resetRigidBody2D();
 
-    Scene* m_scene{nullptr};
+    Scene*      m_scene{nullptr};
     P2D::World* m_world{nullptr};
-    bool m_is_paused{false};
+    bool        m_is_paused{false};
 };
 
 } // namespace GE::Scene

--- a/include/genesis/scene/renderer/renderer_base.h
+++ b/include/genesis/scene/renderer/renderer_base.h
@@ -60,12 +60,12 @@ protected:
     void renderCircleCollider2D(const Entity& entity);
     void renderBoxCollider2D(const Entity& entit);
 
-    bool isValid(std::string_view entity_name, Pipeline* material, Texture* texture,
-                 Mesh* mesh) const;
+    bool
+    isValid(std::string_view entity_name, Pipeline* material, Texture* texture, Mesh* mesh) const;
 
-    GE::Renderer* m_renderer{nullptr};
-    PipelineLibrary m_pipeline_library;
-    PrimitivesRenderer m_primitives_renderer;
+    GE::Renderer*               m_renderer{nullptr};
+    PipelineLibrary             m_pipeline_library;
+    PrimitivesRenderer          m_primitives_renderer;
     const ViewProjectionCamera* m_camera{nullptr};
 };
 

--- a/include/genesis/scene/renderer/wb_oit_renderer.h
+++ b/include/genesis/scene/renderer/wb_oit_renderer.h
@@ -51,7 +51,8 @@ class Entity;
 class WeightedBlendedOITRenderer: public RendererBase
 {
 public:
-    WeightedBlendedOITRenderer(GE::Renderer* renderer, const Assets::Registry& assets,
+    WeightedBlendedOITRenderer(GE::Renderer*               renderer,
+                               const Assets::Registry&     assets,
                                const ViewProjectionCamera* camera);
 
     void render(const Scene& scene) override;
@@ -71,9 +72,9 @@ private:
     void composeScene(GE::Renderer* renderer);
 
     Scoped<Framebuffer> m_wb_oit_fbo;
-    Shared<Pipeline> m_color_pipeline;
-    Shared<Pipeline> m_accumulation_pipeline;
-    Shared<Pipeline> m_composing_pipeline;
+    Shared<Pipeline>    m_color_pipeline;
+    Shared<Pipeline>    m_accumulation_pipeline;
+    Shared<Pipeline>    m_composing_pipeline;
 };
 
 } // namespace GE::Scene

--- a/include/genesis/scene/scene.h
+++ b/include/genesis/scene/scene.h
@@ -83,8 +83,8 @@ public:
 
 private:
     std::string m_name;
-    Registry m_registry;
-    Entity m_main_camera;
+    Registry    m_registry;
+    Entity      m_main_camera;
 };
 
 template<typename... Args>

--- a/include/genesis/scene/scene_deserializer.h
+++ b/include/genesis/scene/scene_deserializer.h
@@ -61,8 +61,8 @@ private:
     void loadMaterialComponent(Entity* entity, const YAML::Node& node);
     void loadSpriteComponent(Entity* entity, const YAML::Node& node);
 
-    Scene m_scene_buffer;
-    Scene* m_scene{nullptr};
+    Scene             m_scene_buffer;
+    Scene*            m_scene{nullptr};
     Assets::Registry* m_assets{nullptr};
 };
 

--- a/include/genesis/window/event_listener.h
+++ b/include/genesis/window/event_listener.h
@@ -39,7 +39,7 @@ namespace GE {
 class GE_API EventListener: public Interface
 {
 public:
-    virtual void onEvent(Event *event) = 0;
+    virtual void onEvent(Event* event) = 0;
 };
 
 } // namespace GE

--- a/include/genesis/window/events/event.h
+++ b/include/genesis/window/events/event.h
@@ -37,15 +37,15 @@
 #include <string>
 #include <typeindex>
 
-#define GE_DECLARE_EVENT_DESCRIPTOR(EventType)             \
-    ::GE::Event::Descriptor getDescriptor() const override \
-    {                                                      \
-        return getStaticDescriptor();                      \
-    }                                                      \
-                                                           \
-    static ::GE::Event::Descriptor getStaticDescriptor()   \
-    {                                                      \
-        return ::GE::Event::Descriptor{typeid(EventType)}; \
+#define GE_DECLARE_EVENT_DESCRIPTOR(EventType)                                                     \
+    ::GE::Event::Descriptor getDescriptor() const override                                         \
+    {                                                                                              \
+        return getStaticDescriptor();                                                              \
+    }                                                                                              \
+                                                                                                   \
+    static ::GE::Event::Descriptor getStaticDescriptor()                                           \
+    {                                                                                              \
+        return ::GE::Event::Descriptor{typeid(EventType)};                                         \
     }
 
 namespace GE {

--- a/include/genesis/window/events/key_events.h
+++ b/include/genesis/window/events/key_events.h
@@ -47,7 +47,7 @@ protected:
     KeyEvent() = default;
     KeyEvent(KeyCode code, KeyModFlags mod);
 
-    KeyCode m_code{KeyCode::UNKNOWN};
+    KeyCode     m_code{KeyCode::UNKNOWN};
     KeyModFlags m_mod{KeyModFlags::NONE};
 };
 

--- a/include/genesis/window/events/mouse_events.h
+++ b/include/genesis/window/events/mouse_events.h
@@ -52,8 +52,8 @@ public:
     GE_DECLARE_EVENT_DESCRIPTOR(MouseMovedEvent);
 
 private:
-    Vec2 m_position{};
-    Vec2 m_offset{};
+    Vec2     m_position{};
+    Vec2     m_offset{};
     uint32_t m_window_id{0};
 };
 

--- a/include/genesis/window/window.h
+++ b/include/genesis/window/window.h
@@ -49,8 +49,8 @@ class GE_API Window: public Interface
 public:
     struct settings_t {
         std::string title{TITLE_DEFAULT};
-        Vec2 size{SIZE_DEFAULT};
-        bool vsync{VSYNC_DEFAULT};
+        Vec2        size{SIZE_DEFAULT};
+        bool        vsync{VSYNC_DEFAULT};
 
         static constexpr auto TITLE_DEFAULT = "Genesis";
         static constexpr Vec2 SIZE_DEFAULT{1280.0f, 720.0f};

--- a/src/genesis/assets/mesh_resource.cpp
+++ b/src/genesis/assets/mesh_resource.cpp
@@ -47,7 +47,7 @@ MeshResource::MeshResource(const std::string& package, const config_t& config)
 }
 
 Shared<MeshResource> MeshResource::Factory::create(const std::string& package,
-                                                   const config_t& config)
+                                                   const config_t&    config)
 {
     try {
         return Shared<MeshResource>{new MeshResource{package, config}};

--- a/src/genesis/assets/package.cpp
+++ b/src/genesis/assets/package.cpp
@@ -38,7 +38,7 @@ namespace GE::Assets {
 namespace {
 
 template<typename T>
-void appendIds(std::vector<ResourceID>* resource_ids,
+void appendIds(std::vector<ResourceID>*                          resource_ids,
                const std::unordered_map<std::string, Shared<T>>& resources)
 {
     resource_ids->reserve(resource_ids->size() + resources.size());

--- a/src/genesis/assets/pipeline_resource.cpp
+++ b/src/genesis/assets/pipeline_resource.cpp
@@ -40,7 +40,7 @@
 
 namespace GE::Assets {
 
-Scoped<Pipeline> PipelineResource::createPipeline(GE::Renderer *renderer,
+Scoped<Pipeline> PipelineResource::createPipeline(GE::Renderer*     renderer,
                                                   pipeline_config_t config) const
 {
     config.vertex_shader = m_vertex_shader;
@@ -48,7 +48,7 @@ Scoped<Pipeline> PipelineResource::createPipeline(GE::Renderer *renderer,
     return renderer->createPipeline(config);
 }
 
-PipelineResource::PipelineResource(const std::string &package, const config_t &config)
+PipelineResource::PipelineResource(const std::string& package, const config_t& config)
     : ResourceBase{{package, GROUP, config.name}}
     , m_vertex_shader_path{config.vertex_shader_path}
     , m_fragment_shader_path{config.fragment_shader_path}
@@ -64,12 +64,12 @@ PipelineResource::PipelineResource(const std::string &package, const config_t &c
     }
 }
 
-Shared<PipelineResource> PipelineResource::Factory::create(const std::string &package,
-                                                           const config_t &config)
+Shared<PipelineResource> PipelineResource::Factory::create(const std::string& package,
+                                                           const config_t&    config)
 {
     try {
         return Shared<PipelineResource>{new PipelineResource{package, config}};
-    } catch (const GE::Exception &e) {
+    } catch (const GE::Exception& e) {
         GE_CORE_ERR("Failed to create a pipeline resource: '{}'", e.what());
         return nullptr;
     }

--- a/src/genesis/assets/resource_serializer.cpp
+++ b/src/genesis/assets/resource_serializer.cpp
@@ -44,7 +44,7 @@
 namespace GE::Assets {
 namespace {
 
-bool writeToFile(const std::string &filepath, const YAML::Node &node)
+bool writeToFile(const std::string& filepath, const YAML::Node& node)
 {
     std::ofstream fout{filepath};
     if (!fout) {
@@ -58,11 +58,11 @@ bool writeToFile(const std::string &filepath, const YAML::Node &node)
 
 } // namespace
 
-ResourceSerializer::ResourceSerializer(Registry *registry)
+ResourceSerializer::ResourceSerializer(Registry* registry)
     : m_registry{registry}
 {}
 
-bool ResourceSerializer::serialize(const std::string &config_filepath)
+bool ResourceSerializer::serialize(const std::string& config_filepath)
 {
     auto assets = serializeAssets();
 
@@ -80,7 +80,7 @@ YAML::Node ResourceSerializer::serializeAssets()
 
     auto resources_node = assets_node["packages"];
 
-    for (const auto *package : m_registry->allPackages()) {
+    for (const auto* package : m_registry->allPackages()) {
         auto package_node = serializePackage(*package);
 
         if (writeToFile(package->filepath(), package_node)) {
@@ -91,22 +91,22 @@ YAML::Node ResourceSerializer::serializeAssets()
     return assets_node;
 }
 
-YAML::Node ResourceSerializer::serializePackage(const Package &package)
+YAML::Node ResourceSerializer::serializePackage(const Package& package)
 {
     YAML::Node package_node;
 
     package_node["name"] = package.name();
     auto resources_node = package_node["resources"];
 
-    for (const auto &pipeline : package.getAllOf<PipelineResource>()) {
+    for (const auto& pipeline : package.getAllOf<PipelineResource>()) {
         resources_node[GE::toString(Group::PIPELINES)].push_back(YAML::Node{*pipeline});
     }
 
-    for (const auto &mesh : package.getAllOf<MeshResource>()) {
+    for (const auto& mesh : package.getAllOf<MeshResource>()) {
         resources_node[GE::toString(Group::MESHES)].push_back(YAML::Node{*mesh});
     }
 
-    for (const auto &texture : package.getAllOf<TextureResource>()) {
+    for (const auto& texture : package.getAllOf<TextureResource>()) {
         resources_node[GE::toString(Group::TEXTURES)].push_back(YAML::Node{*texture});
     }
 

--- a/src/genesis/assets/texture_resource.cpp
+++ b/src/genesis/assets/texture_resource.cpp
@@ -51,7 +51,7 @@ TextureResource::TextureResource(const std::string& package, const config_t& con
 }
 
 Shared<TextureResource> TextureResource::Factory::create(const std::string& package,
-                                                         const config_t& config)
+                                                         const config_t&    config)
 {
     try {
         return Shared<TextureResource>{new TextureResource{package, config}};

--- a/src/genesis/graphics/index_buffer.cpp
+++ b/src/genesis/graphics/index_buffer.cpp
@@ -36,7 +36,7 @@
 
 namespace GE {
 
-Scoped<IndexBuffer> IndexBuffer::create(const uint32_t *indices, uint32_t count)
+Scoped<IndexBuffer> IndexBuffer::create(const uint32_t* indices, uint32_t count)
 {
     return Graphics::factory()->createIndexBuffer(indices, count);
 }

--- a/src/genesis/graphics/mesh.cpp
+++ b/src/genesis/graphics/mesh.cpp
@@ -82,10 +82,10 @@ void Mesh::destroy()
 
 bool Mesh::populateBuffers(const tinyobj::ObjReader& reader)
 {
-    const auto& attrib = reader.GetAttrib();
+    const auto&                            attrib = reader.GetAttrib();
     std::unordered_map<vertex_t, uint32_t> unique_vertices;
-    std::vector<vertex_t> vertices;
-    std::vector<uint32_t> indices;
+    std::vector<vertex_t>                  vertices;
+    std::vector<uint32_t>                  indices;
 
     for (const auto& shape : reader.GetShapes()) {
         for (const auto& index : shape.mesh.indices) {

--- a/src/genesis/graphics/primitives_renderer.cpp
+++ b/src/genesis/graphics/primitives_renderer.cpp
@@ -96,7 +96,7 @@ Scoped<VertexBuffer> createCircleVBO(uint64_t segment_count)
 {
     constexpr float CIRCLE_RADIUS{0.5f};
 
-    float angle = 2.0f * M_PI / segment_count;
+    float             angle = 2.0f * M_PI / segment_count;
     std::vector<Vec2> vertices(segment_count);
 
     for (uint64_t i{0}; i < segment_count; i++) {

--- a/src/genesis/graphics/render_command.cpp
+++ b/src/genesis/graphics/render_command.cpp
@@ -41,61 +41,65 @@
 
 namespace GE {
 
-RenderCommand::RenderCommand(Renderer *renderer)
+RenderCommand::RenderCommand(Renderer* renderer)
     : m_renderer{renderer}
 {}
 
-void RenderCommand::bind(Pipeline *pipeline)
+void RenderCommand::bind(Pipeline* pipeline)
 {
     pipeline->bind(&m_cmd_queue);
 }
 
-void RenderCommand::bind(VertexBuffer *buffer)
+void RenderCommand::bind(VertexBuffer* buffer)
 {
     buffer->bind(&m_cmd_queue);
 }
 
-void RenderCommand::bind(IndexBuffer *buffer)
+void RenderCommand::bind(IndexBuffer* buffer)
 {
     buffer->bind(&m_cmd_queue);
 }
 
-void RenderCommand::bind(Pipeline *pipeline, const std::string &resource_name,
-                         const UniformBuffer &buffer)
+void RenderCommand::bind(Pipeline*            pipeline,
+                         const std::string&   resource_name,
+                         const UniformBuffer& buffer)
 {
     pipeline->bind(&m_cmd_queue, resource_name, buffer);
 }
 
-void RenderCommand::bind(Pipeline *pipeline, const std::string &resource_name,
-                         const Texture &texture)
+void RenderCommand::bind(Pipeline*          pipeline,
+                         const std::string& resource_name,
+                         const Texture&     texture)
 {
     pipeline->bind(&m_cmd_queue, resource_name, texture);
 }
 
-void RenderCommand::draw(const Mesh &mesh)
+void RenderCommand::draw(const Mesh& mesh)
 {
     mesh.draw(&m_cmd_queue);
 }
 
-void RenderCommand::draw(VertexBuffer *buffer, uint32_t vertex_count)
+void RenderCommand::draw(VertexBuffer* buffer, uint32_t vertex_count)
 {
     buffer->bind(&m_cmd_queue);
     buffer->draw(&m_cmd_queue, vertex_count);
 }
 
-void RenderCommand::draw(VertexBuffer *vbo, IndexBuffer *ibo)
+void RenderCommand::draw(VertexBuffer* vbo, IndexBuffer* ibo)
 {
     vbo->bind(&m_cmd_queue);
     ibo->bind(&m_cmd_queue);
     vbo->draw(&m_cmd_queue, ibo);
 }
 
-void RenderCommand::draw(GUI::Context *gui_layer)
+void RenderCommand::draw(GUI::Context* gui_layer)
 {
     gui_layer->draw(&m_cmd_queue);
 }
 
-void RenderCommand::draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_vertex,
+void RenderCommand::draw(uint32_t vertex_count,
+                         uint32_t instance_count,
+                         uint32_t first_vertex,
                          uint32_t first_instance)
 {
     m_renderer->draw(&m_cmd_queue, vertex_count, instance_count, first_vertex, first_instance);

--- a/src/genesis/graphics/shader_precompiler.cpp
+++ b/src/genesis/graphics/shader_precompiler.cpp
@@ -53,7 +53,7 @@ std::optional<shaderc_shader_kind> toShaderKind(GE::Shader::Type type)
     }
 }
 
-std::string readShaderCode(const std::string &filepath)
+std::string readShaderCode(const std::string& filepath)
 {
     if (auto file = GE::FS::readFile<char>(filepath); !file.empty()) {
         return {file.begin(), file.end()};
@@ -67,20 +67,21 @@ std::string readShaderCode(const std::string &filepath)
 
 namespace GE {
 
-ShaderCache ShaderPrecompiler::compileFromFile(Shader::Type shader_type,
-                                               const std::string &filepath)
+ShaderCache ShaderPrecompiler::compileFromFile(Shader::Type       shader_type,
+                                               const std::string& filepath)
 {
     return compileShader(shader_type, readShaderCode(filepath), filepath);
 }
 
-ShaderCache ShaderPrecompiler::compileFromSource(Shader::Type shader_type,
-                                                 const std::string &source_code)
+ShaderCache ShaderPrecompiler::compileFromSource(Shader::Type       shader_type,
+                                                 const std::string& source_code)
 {
     return compileShader(shader_type, source_code, "<no-filename>");
 }
 
-ShaderCache ShaderPrecompiler::compileShader(Shader::Type type, const std::string &source_code,
-                                             const std::string &filepath)
+ShaderCache ShaderPrecompiler::compileShader(Shader::Type       type,
+                                             const std::string& source_code,
+                                             const std::string& filepath)
 {
     if (source_code.empty()) {
         GE_CORE_ERR("Shader Source code is empty");
@@ -105,7 +106,7 @@ ShaderCache ShaderPrecompiler::compileShader(Shader::Type type, const std::strin
     return {result.begin(), result.end()};
 }
 
-ShaderCache ShaderPrecompiler::loadShaderCache(const std::string &filepath)
+ShaderCache ShaderPrecompiler::loadShaderCache(const std::string& filepath)
 {
     if (std::ifstream file{filepath, std::ios::binary}; file) {
         file >> std::noskipws;
@@ -116,10 +117,10 @@ ShaderCache ShaderPrecompiler::loadShaderCache(const std::string &filepath)
     return {};
 }
 
-bool ShaderPrecompiler::saveShaderCache(const ShaderCache &shader_cache,
-                                        const std::string &filepath)
+bool ShaderPrecompiler::saveShaderCache(const ShaderCache& shader_cache,
+                                        const std::string& filepath)
 {
-    auto cache_dir = std::filesystem::path{filepath}.parent_path();
+    auto            cache_dir = std::filesystem::path{filepath}.parent_path();
     std::error_code error_code;
 
     if (!std::filesystem::exists(cache_dir) &&

--- a/src/genesis/graphics/shader_reflection.cpp
+++ b/src/genesis/graphics/shader_reflection.cpp
@@ -87,7 +87,7 @@ uint32_t toResourceDescriptorCount(const spirv_cross::SmallVector<uint32_t>& typ
 
 GE::resource_descriptor_t toResourceDescriptors(const spirv_cross::Compiler& compiler,
                                                 const spirv_cross::Resource& resource,
-                                                DescType type)
+                                                DescType                     type)
 {
     return {
         .name = resource.name,
@@ -111,7 +111,7 @@ std::string toPushConstantName(const spirv_cross::Resource& resource, std::strin
 
 GE::push_constant_t toPushConstant(const spirv_cross::Compiler& compiler,
                                    const spirv_cross::Resource& push_constant_buffer,
-                                   uint32_t member_index)
+                                   uint32_t                     member_index)
 {
     const auto& buffer_type = compiler.get_type(push_constant_buffer.base_type_id);
     const auto& member_name = compiler.get_member_name(buffer_type.self, member_index);
@@ -148,7 +148,7 @@ ShaderInputLayout ShaderReflection::inputLayout() const
         return {};
     }
 
-    const auto& resources = m_pimpl->compiler.get_shader_resources();
+    const auto&                    resources = m_pimpl->compiler.get_shader_resources();
     std::deque<shader_attribute_t> attributes;
 
     for (const auto& resource : resources.stage_inputs) {
@@ -177,8 +177,8 @@ ResourceDescriptors ShaderReflection::resourceDescriptors() const
     using Resources = spirv_cross::SmallVector<spirv_cross::Resource>;
 
     ResourceDescriptors descriptors;
-    const auto& compiler = m_pimpl->compiler;
-    const auto& resources = compiler.get_shader_resources();
+    const auto&         compiler = m_pimpl->compiler;
+    const auto&         resources = compiler.get_shader_resources();
 
     auto fill_descriptors = [&compiler, &descriptors](const Resources& resources, DescType type) {
         for (const auto& resource : resources) {
@@ -198,8 +198,8 @@ PushConstants ShaderReflection::pushConstants() const
     }
 
     PushConstants push_constants;
-    const auto& compiler = m_pimpl->compiler;
-    const auto& resources = compiler.get_shader_resources();
+    const auto&   compiler = m_pimpl->compiler;
+    const auto&   resources = compiler.get_shader_resources();
 
     for (const auto& push_constant_buffer : resources.push_constant_buffers) {
         const auto& buffer_type = compiler.get_type(push_constant_buffer.base_type_id);

--- a/src/genesis/graphics/texture_loader.cpp
+++ b/src/genesis/graphics/texture_loader.cpp
@@ -72,10 +72,13 @@ TextureFormat toTextureFormat(int channel_count, bool is_hdr)
     return TextureFormat::UNKNOWN;
 }
 
-void* stbiLoadWrapper(const std::vector<uint8_t>& memory, int* width, int* height,
-                      int* channel_count, int desired_channels)
+void* stbiLoadWrapper(const std::vector<uint8_t>& memory,
+                      int*                        width,
+                      int*                        height,
+                      int*                        channel_count,
+                      int                         desired_channels)
 {
-    int memory_size = static_cast<int>(memory.size());
+    int  memory_size = static_cast<int>(memory.size());
     bool is_hdr = ::stbi_is_hdr_from_memory(memory.data(), memory_size) != 0;
 
     if (!is_hdr) {
@@ -129,9 +132,9 @@ bool isOpaque(const void* texture_data, int width, int height, int channel_count
 
 std::pair<void*, texture_config_t> loadStbiTexture(const std::vector<uint8_t>& data)
 {
-    int width{};
-    int height{};
-    int channel_count{};
+    int   width{};
+    int   height{};
+    int   channel_count{};
     void* texture_data{nullptr};
 
     texture_data = stbiLoadWrapper(data, &width, &height, &channel_count, 0);
@@ -156,8 +159,8 @@ std::pair<void*, texture_config_t> loadStbiTexture(const std::vector<uint8_t>& d
         return {};
     }
 
-    int data_size = static_cast<int>(data.size());
-    bool is_hdr = ::stbi_is_hdr_from_memory(data.data(), data_size) != 0;
+    int           data_size = static_cast<int>(data.size());
+    bool          is_hdr = ::stbi_is_hdr_from_memory(data.data(), data_size) != 0;
     TextureFormat format = toTextureFormat(channel_count, is_hdr);
 
     texture_config_t config{};

--- a/src/genesis/graphics/uniform_buffer.cpp
+++ b/src/genesis/graphics/uniform_buffer.cpp
@@ -36,7 +36,7 @@
 
 namespace GE {
 
-Scoped<UniformBuffer> UniformBuffer::create(uint32_t size, const void *data)
+Scoped<UniformBuffer> UniformBuffer::create(uint32_t size, const void* data)
 {
     return Graphics::factory()->createUniformBuffer(size, data);
 }

--- a/src/genesis/graphics/vulkan/buffers/buffer_base.cpp
+++ b/src/genesis/graphics/vulkan/buffers/buffer_base.cpp
@@ -48,13 +48,14 @@ BufferBase::~BufferBase()
     destroyVkHandles();
 }
 
-void BufferBase::copyFromHost(uint32_t size, const void *data, uint32_t offset)
+void BufferBase::copyFromHost(uint32_t size, const void* data, uint32_t offset)
 {
     StagingBuffer staging_buffer{m_device, size, data};
     staging_buffer.copyTo(this, offset);
 }
 
-void BufferBase::createBuffer(uint32_t size, VkBufferUsageFlags usage,
+void BufferBase::createBuffer(uint32_t              size,
+                              VkBufferUsageFlags    usage,
                               VkMemoryPropertyFlags properties)
 {
     GE_ASSERT(m_buffer == VK_NULL_HANDLE, "Buffer has already been allocated");

--- a/src/genesis/graphics/vulkan/buffers/buffer_base.h
+++ b/src/genesis/graphics/vulkan/buffers/buffer_base.h
@@ -56,9 +56,9 @@ protected:
     void destroyVkHandles();
 
     Shared<Device> m_device;
-    VkBuffer m_buffer{VK_NULL_HANDLE};
+    VkBuffer       m_buffer{VK_NULL_HANDLE};
     VkDeviceMemory m_memory{VK_NULL_HANDLE};
-    uint32_t m_size{};
+    uint32_t       m_size{};
 };
 
 constexpr VkBuffer toVkBuffer(void* buffer)

--- a/src/genesis/graphics/vulkan/buffers/index_buffer.cpp
+++ b/src/genesis/graphics/vulkan/buffers/index_buffer.cpp
@@ -41,7 +41,7 @@ IndexBuffer::IndexBuffer(Shared<Device> device, const uint32_t* indices, uint32_
     : BufferBase{std::move(device)}
     , m_count{count}
 {
-    const uint32_t size = count * sizeof(uint32_t);
+    const uint32_t     size = count * sizeof(uint32_t);
     VkBufferUsageFlags usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     VkMemoryPropertyFlagBits properties = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     createBuffer(size, usage, properties);

--- a/src/genesis/graphics/vulkan/buffers/staging_buffer.cpp
+++ b/src/genesis/graphics/vulkan/buffers/staging_buffer.cpp
@@ -44,7 +44,7 @@
 namespace GE::Vulkan {
 namespace {
 
-constexpr VkBufferUsageFlags USAGE{VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+constexpr VkBufferUsageFlags    USAGE{VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
                                    VK_BUFFER_USAGE_TRANSFER_DST_BIT};
 constexpr VkMemoryPropertyFlags PROPERTIES{VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
                                            VK_MEMORY_PROPERTY_HOST_COHERENT_BIT};
@@ -55,14 +55,14 @@ StagingBuffer::StagingBuffer(Shared<Device> device)
     : BufferBase{std::move(device)}
 {}
 
-StagingBuffer::StagingBuffer(Shared<Device> device, uint32_t size, const void *data)
+StagingBuffer::StagingBuffer(Shared<Device> device, uint32_t size, const void* data)
     : BufferBase{std::move(device)}
 {
     createBuffer(size, USAGE, PROPERTIES);
     copyData(size, data, 0);
 }
 
-void *StagingBuffer::data()
+void* StagingBuffer::data()
 {
     if (m_size == 0) {
         return nullptr;
@@ -93,21 +93,21 @@ void StagingBuffer::clear()
     m_size = 0;
 }
 
-void StagingBuffer::copyTo(BufferBase *dest, uint32_t offset)
+void StagingBuffer::copyTo(BufferBase* dest, uint32_t offset)
 {
     GE_CORE_ASSERT(m_size > 0, "Trying to copy empty buffer");
 
     SingleCommand cmd{m_device};
-    VkBufferCopy copy_region{};
+    VkBufferCopy  copy_region{};
     copy_region.srcOffset = 0;
     copy_region.dstOffset = offset;
     copy_region.size = m_size;
     vkCmdCopyBuffer(cmd.buffer(), m_buffer, dest->buffer(), 1, &copy_region);
 }
 
-void StagingBuffer::copyData(uint32_t size, const void *data, uint32_t offset)
+void StagingBuffer::copyData(uint32_t size, const void* data, uint32_t offset)
 {
-    void *mem_ptr{nullptr};
+    void* mem_ptr{nullptr};
     vkMapMemory(m_device->device(), m_memory, offset, size, 0, &mem_ptr);
     std::memcpy(mem_ptr, data, size);
     vkUnmapMemory(m_device->device(), m_memory);

--- a/src/genesis/graphics/vulkan/buffers/uniform_buffer.cpp
+++ b/src/genesis/graphics/vulkan/buffers/uniform_buffer.cpp
@@ -34,7 +34,7 @@
 
 namespace GE::Vulkan {
 
-UniformBuffer::UniformBuffer(Shared<Device> device, uint32_t size, const void *data)
+UniformBuffer::UniformBuffer(Shared<Device> device, uint32_t size, const void* data)
     : Vulkan::BufferBase{std::move(device)}
 {
     VkBufferUsageFlags usage =
@@ -47,7 +47,7 @@ UniformBuffer::UniformBuffer(Shared<Device> device, uint32_t size, const void *d
     }
 }
 
-void UniformBuffer::setData(size_t size, const void *data)
+void UniformBuffer::setData(size_t size, const void* data)
 {
     copyFromHost(size, data, 0);
 }

--- a/src/genesis/graphics/vulkan/buffers/uniform_buffer.h
+++ b/src/genesis/graphics/vulkan/buffers/uniform_buffer.h
@@ -41,12 +41,12 @@ namespace GE::Vulkan {
 class UniformBuffer: public GE::UniformBuffer, BufferBase
 {
 public:
-    UniformBuffer(Shared<Device> device, uint32_t size, const void *data);
+    UniformBuffer(Shared<Device> device, uint32_t size, const void* data);
 
     NativeHandle nativeHandle() const override { return buffer(); }
     uint32_t size() const override { return m_size; }
 
-    void setData(size_t size, const void *data) override;
+    void setData(size_t size, const void* data) override;
 };
 
 } // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/buffers/vertex_buffer.cpp
+++ b/src/genesis/graphics/vulkan/buffers/vertex_buffer.cpp
@@ -40,7 +40,7 @@
 
 namespace GE::Vulkan {
 
-VertexBuffer::VertexBuffer(Shared<Device> device, uint32_t size, const void *vertices)
+VertexBuffer::VertexBuffer(Shared<Device> device, uint32_t size, const void* vertices)
     : BufferBase{std::move(device)}
 {
     VkBufferUsageFlags usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
@@ -52,27 +52,27 @@ VertexBuffer::VertexBuffer(Shared<Device> device, uint32_t size, const void *ver
     }
 }
 
-void VertexBuffer::bind(GPUCommandQueue *queue) const
+void VertexBuffer::bind(GPUCommandQueue* queue) const
 {
-    queue->enqueue([this](void *cmd) {
+    queue->enqueue([this](void* cmd) {
         constexpr VkDeviceSize offsets{0};
         vkCmdBindVertexBuffers(toVkCommandBuffer(cmd), 0, 1, &m_buffer, &offsets);
     });
 }
 
-void VertexBuffer::draw(GPUCommandQueue *queue, uint32_t vertex_count) const
+void VertexBuffer::draw(GPUCommandQueue* queue, uint32_t vertex_count) const
 {
     queue->enqueue(
-        [vertex_count](void *cmd) { vkCmdDraw(toVkCommandBuffer(cmd), vertex_count, 1, 0, 0); });
+        [vertex_count](void* cmd) { vkCmdDraw(toVkCommandBuffer(cmd), vertex_count, 1, 0, 0); });
 }
 
-void VertexBuffer::draw(GPUCommandQueue *queue, GE::IndexBuffer *ibo) const
+void VertexBuffer::draw(GPUCommandQueue* queue, GE::IndexBuffer* ibo) const
 {
     queue->enqueue(
-        [ibo](void *cmd) { vkCmdDrawIndexed(toVkCommandBuffer(cmd), ibo->count(), 1, 0, 0, 0); });
+        [ibo](void* cmd) { vkCmdDrawIndexed(toVkCommandBuffer(cmd), ibo->count(), 1, 0, 0, 0); });
 }
 
-void VertexBuffer::setVertices(const void *vertices, uint32_t size)
+void VertexBuffer::setVertices(const void* vertices, uint32_t size)
 {
     GE_ASSERT(m_size >= size, "Vertex Buffer overflow");
     copyFromHost(size, vertices, 0);

--- a/src/genesis/graphics/vulkan/descriptor_pool.cpp
+++ b/src/genesis/graphics/vulkan/descriptor_pool.cpp
@@ -93,8 +93,8 @@ VkDescriptorSet DescriptorPool::allocateDescriptorSet(VkDescriptorSetLayout layo
     }
 
     VkDescriptorSet set{VK_NULL_HANDLE};
-    auto* pool = getPool();
-    auto result = allocateDescriptorSet(pool, layout, &set);
+    auto*           pool = getPool();
+    auto            result = allocateDescriptorSet(pool, layout, &set);
 
     if (result == VK_SUCCESS) {
         return m_cache[layout] = set;
@@ -119,8 +119,9 @@ void DescriptorPool::reset()
         m_pools, [this](auto pool) { vkResetDescriptorPool(m_device->device(), pool, 0); });
 }
 
-VkResult DescriptorPool::allocateDescriptorSet(VkDescriptorPool pool, VkDescriptorSetLayout layout,
-                                               VkDescriptorSet* set)
+VkResult DescriptorPool::allocateDescriptorSet(VkDescriptorPool      pool,
+                                               VkDescriptorSetLayout layout,
+                                               VkDescriptorSet*      set)
 {
     VkDescriptorSetAllocateInfo alloc_info{};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;

--- a/src/genesis/graphics/vulkan/descriptor_pool.h
+++ b/src/genesis/graphics/vulkan/descriptor_pool.h
@@ -56,17 +56,18 @@ public:
     static constexpr uint32_t MAX_COUNT_DEFAULT{1000};
 
 private:
-    VkResult allocateDescriptorSet(VkDescriptorPool pool, VkDescriptorSetLayout layout,
-                                   VkDescriptorSet* set);
+    VkResult allocateDescriptorSet(VkDescriptorPool      pool,
+                                   VkDescriptorSetLayout layout,
+                                   VkDescriptorSet*      set);
     VkDescriptorPool getPool();
     VkDescriptorPool createPool();
 
     void destroyVkHandles();
 
-    Shared<Device> m_device;
-    std::list<VkDescriptorPool> m_pools;
-    std::vector<VkDescriptorPoolSize> m_sizes;
-    uint32_t m_max_count{};
+    Shared<Device>                                             m_device;
+    std::list<VkDescriptorPool>                                m_pools;
+    std::vector<VkDescriptorPoolSize>                          m_sizes;
+    uint32_t                                                   m_max_count{};
     std::unordered_map<VkDescriptorSetLayout, VkDescriptorSet> m_cache;
 };
 

--- a/src/genesis/graphics/vulkan/device.cpp
+++ b/src/genesis/graphics/vulkan/device.cpp
@@ -50,12 +50,12 @@ std::string toString(VkPhysicalDevice physical_device)
     return device_properties.deviceName;
 }
 
-std::string toString(const std::vector<VkPhysicalDevice> &physical_devices)
+std::string toString(const std::vector<VkPhysicalDevice>& physical_devices)
 {
     std::string string;
 
     for (size_t i{0}; i < physical_devices.size(); i++) {
-        const auto &device = physical_devices[i];
+        const auto& device = physical_devices[i];
         string += GE_FMTSTR("- Name: {}", toString(device));
         string += i != physical_devices.size() - 1 ? "\n" : "";
     }
@@ -78,8 +78,9 @@ bool isComputeQueue(VkQueueFamilyProperties queue_family)
     return (queue_family.queueFlags & VK_QUEUE_COMPUTE_BIT) != 0;
 }
 
-bool isPresentSupported(VkPhysicalDevice physical_device, VkSurfaceKHR surface,
-                        uint32_t queue_family_idx)
+bool isPresentSupported(VkPhysicalDevice physical_device,
+                        VkSurfaceKHR     surface,
+                        uint32_t         queue_family_idx)
 {
     VkBool32 is_present_supported{VK_FALSE};
     vkGetPhysicalDeviceSurfaceSupportKHR(physical_device, queue_family_idx, surface,
@@ -104,8 +105,8 @@ uint8_t getMaxMSAA(VkSampleCountFlags device_count)
     return static_cast<uint8_t>(VK_SAMPLE_COUNT_1_BIT);
 }
 
-void appendMandatoryDeviceExtensions(VkPhysicalDevice physical_device,
-                                     std::vector<const char *> *ext)
+void appendMandatoryDeviceExtensions(VkPhysicalDevice          physical_device,
+                                     std::vector<const char*>* ext)
 {
     static const std::unordered_set<std::string_view> mandatory_ext = {
         "VK_KHR_portability_subset",
@@ -114,7 +115,7 @@ void appendMandatoryDeviceExtensions(VkPhysicalDevice physical_device,
     auto device_extensions = vulkanGet<VkExtensionProperties>(
         ::vkEnumerateDeviceExtensionProperties, physical_device, nullptr);
 
-    for (const auto &device_ext : device_extensions) {
+    for (const auto& device_ext : device_extensions) {
         if (auto it = mandatory_ext.find(device_ext.extensionName); it != mandatory_ext.end()) {
             ext->push_back(it->data());
         }
@@ -148,8 +149,9 @@ void Device::waitIdle()
     vkDeviceWaitIdle(m_device);
 }
 
-VkFormat Device::getSupportedFormat(const std::vector<VkFormat> &candidates, VkImageTiling tiling,
-                                    VkFormatFeatureFlags features)
+VkFormat Device::getSupportedFormat(const std::vector<VkFormat>& candidates,
+                                    VkImageTiling                tiling,
+                                    VkFormatFeatureFlags         features)
 {
     for (auto format : candidates) {
         VkFormatProperties props{};
@@ -175,11 +177,11 @@ VkFormat Device::getSupportedFormat(const std::vector<VkFormat> &candidates, VkI
 void Device::pickPhysicalDevice()
 {
     VkInstance instance = Instance::instance();
-    auto devices = vulkanGet<VkPhysicalDevice>(::vkEnumeratePhysicalDevices, instance);
+    auto       devices = vulkanGet<VkPhysicalDevice>(::vkEnumeratePhysicalDevices, instance);
 
     GE_CORE_INFO("Physical Device List: \n{}", toString(devices));
 
-    for (const auto &device : devices) {
+    for (const auto& device : devices) {
         if (isPhysicalDeviceSuitable(device)) {
             GE_CORE_INFO("Picked Physical Device: {}", toString(device));
             m_physical_device = device;
@@ -194,7 +196,7 @@ void Device::pickPhysicalDevice()
 void Device::createLogicalDevice()
 {
     std::vector<VkDeviceQueueCreateInfo> queue_create_infos;
-    std::unordered_set<uint32_t> unique_queue_families = {
+    std::unordered_set<uint32_t>         unique_queue_families = {
         m_queue_indices.graphics_family.value(),
         m_queue_indices.present_family.value(),
         m_queue_indices.transfer_family.value(),
@@ -301,7 +303,7 @@ bool Device::isPhysicalDeviceSuitable(VkPhysicalDevice physical_device)
 queue_family_indices_t Device::findQueueFamilies(VkPhysicalDevice physical_device)
 {
     queue_family_indices_t indices{};
-    auto queue_families = vulkanGet<VkQueueFamilyProperties>(
+    auto                   queue_families = vulkanGet<VkQueueFamilyProperties>(
         ::vkGetPhysicalDeviceQueueFamilyProperties, physical_device);
 
     for (uint32_t i{0}; i < queue_families.size(); i++) {
@@ -336,8 +338,8 @@ uint32_t Device::findMemoryType(uint32_t type_filter, VkMemoryPropertyFlags prop
 
     for (uint32_t i{0}; i < mem_properties.memoryTypeCount; i++) {
         uint32_t mem_type = 1 << i;
-        bool is_type_suitable = (type_filter & mem_type) != 0;
-        bool is_properties_suitable =
+        bool     is_type_suitable = (type_filter & mem_type) != 0;
+        bool     is_properties_suitable =
             (mem_properties.memoryTypes[i].propertyFlags & properties) != 0;
 
         if (is_type_suitable && is_properties_suitable) {
@@ -355,7 +357,7 @@ bool Device::checkPhysicalDeviceExtSupport(VkPhysicalDevice physical_device)
     std::unordered_set<std::string> required_extensions = {m_extensions.begin(),
                                                            m_extensions.end()};
 
-    for (const auto &extension : device_extensions) {
+    for (const auto& extension : device_extensions) {
         required_extensions.erase(extension.extensionName);
     }
 

--- a/src/genesis/graphics/vulkan/device.h
+++ b/src/genesis/graphics/vulkan/device.h
@@ -57,9 +57,9 @@ struct queue_family_indices_t {
 };
 
 struct swap_chain_support_details_t {
-    VkSurfaceCapabilitiesKHR capabilities{};
+    VkSurfaceCapabilitiesKHR        capabilities{};
     std::vector<VkSurfaceFormatKHR> formats;
-    std::vector<VkPresentModeKHR> present_mode;
+    std::vector<VkPresentModeKHR>   present_mode;
 
     bool isValid() const { return !formats.empty() && !present_mode.empty(); }
 };
@@ -88,8 +88,9 @@ public:
         return querySwapChainSupport(m_physical_device);
     }
 
-    VkFormat getSupportedFormat(const std::vector<VkFormat>& candidates, VkImageTiling tiling,
-                                VkFormatFeatureFlags features);
+    VkFormat getSupportedFormat(const std::vector<VkFormat>& candidates,
+                                VkImageTiling                tiling,
+                                VkFormatFeatureFlags         features);
     uint32_t findMemoryType(uint32_t type_filter, VkMemoryPropertyFlags properties);
 
 private:
@@ -105,17 +106,17 @@ private:
     bool checkPhysicalDeviceExtSupport(VkPhysicalDevice physical_device);
     swap_chain_support_details_t querySwapChainSupport(VkPhysicalDevice physical_device) const;
 
-    VkSurfaceKHR m_surface{VK_NULL_HANDLE};
+    VkSurfaceKHR     m_surface{VK_NULL_HANDLE};
     VkPhysicalDevice m_physical_device{VK_NULL_HANDLE};
-    VkDevice m_device{VK_NULL_HANDLE};
-    VkCommandPool m_command_pool{VK_NULL_HANDLE};
+    VkDevice         m_device{VK_NULL_HANDLE};
+    VkCommandPool    m_command_pool{VK_NULL_HANDLE};
 
     VkQueue m_graphics_queue{VK_NULL_HANDLE};
     VkQueue m_present_queue{VK_NULL_HANDLE};
     VkQueue m_transfer_queue{VK_NULL_HANDLE};
     VkQueue m_compute_queue{VK_NULL_HANDLE};
 
-    queue_family_indices_t m_queue_indices{};
+    queue_family_indices_t    m_queue_indices{};
     GraphicsContext::limits_t m_limits{};
 
     std::vector<const char*> m_extensions;

--- a/src/genesis/graphics/vulkan/framebuffer.h
+++ b/src/genesis/graphics/vulkan/framebuffer.h
@@ -77,19 +77,19 @@ private:
 
     void clearResources();
 
-    Shared<Device> m_device;
+    Shared<Device>              m_device;
     Scoped<FramebufferRenderer> m_renderer;
-    config_t m_config;
+    config_t                    m_config;
 
-    std::vector<Scoped<Vulkan::Texture>> m_color_textures;
-    std::vector<Scoped<Image>> m_color_msaa_images;
+    std::vector<Scoped<Vulkan::Texture>>   m_color_textures;
+    std::vector<Scoped<Image>>             m_color_msaa_images;
     std::vector<VkRenderingAttachmentInfo> m_color_rendering_attachments;
-    std::vector<Vec4> m_clear_color;
+    std::vector<Vec4>                      m_clear_color;
 
-    Scoped<Vulkan::Texture> m_depth_texture;
-    Scoped<Image> m_depth_msaa_image;
+    Scoped<Vulkan::Texture>   m_depth_texture;
+    Scoped<Image>             m_depth_msaa_image;
     VkRenderingAttachmentInfo m_depth_rendering_attachment{};
-    float m_clear_depth{1.0f};
+    float                     m_clear_depth{1.0f};
 };
 
 } // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/graphics_context.cpp
+++ b/src/genesis/graphics/vulkan/graphics_context.cpp
@@ -47,7 +47,7 @@ namespace {
 VkSurfaceKHR createSurface(void* window)
 {
     VkSurfaceKHR surface{VK_NULL_HANDLE};
-    auto* sdl_window = reinterpret_cast<SDL_Window*>(window);
+    auto*        sdl_window = reinterpret_cast<SDL_Window*>(window);
 
     if (::SDL_Vulkan_CreateSurface(sdl_window, GE::Vulkan::Instance::instance(), &surface) ==
         SDL_FALSE) {
@@ -60,8 +60,8 @@ VkSurfaceKHR createSurface(void* window)
 inline GE::Vec2 getWindowSize(void* window)
 {
     auto* sdl_window = reinterpret_cast<SDL_Window*>(window);
-    int width{0};
-    int height{0};
+    int   width{0};
+    int   height{0};
     ::SDL_GetWindowSize(sdl_window, &width, &height);
     return {width, height};
 }

--- a/src/genesis/graphics/vulkan/graphics_context.h
+++ b/src/genesis/graphics/vulkan/graphics_context.h
@@ -69,12 +69,12 @@ private:
     void clearResources();
     void destroyVulkanHandles();
 
-    VkSurfaceKHR m_surface{VK_NULL_HANDLE};
+    VkSurfaceKHR           m_surface{VK_NULL_HANDLE};
     Shared<Vulkan::Device> m_device;
 
     Scoped<GE::GraphicsFactory> m_factory;
-    Scoped<WindowRenderer> m_window_renderer;
-    Scoped<GE::GUI::Context> m_gui;
+    Scoped<WindowRenderer>      m_window_renderer;
+    Scoped<GE::GUI::Context>    m_gui;
 };
 
 } // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/graphics_factory.cpp
+++ b/src/genesis/graphics/vulkan/graphics_factory.cpp
@@ -46,19 +46,19 @@ GraphicsFactory::GraphicsFactory(Shared<Device> device)
 {}
 
 Scoped<GE::Framebuffer>
-GraphicsFactory::createFramebuffer(const Framebuffer::config_t &config) const
+GraphicsFactory::createFramebuffer(const Framebuffer::config_t& config) const
 {
     return tryMakeScoped<Vulkan::Framebuffer>(m_device, config);
 }
 
-Scoped<GE::IndexBuffer> GraphicsFactory::createIndexBuffer(const uint32_t *indices,
-                                                           uint32_t count) const
+Scoped<GE::IndexBuffer> GraphicsFactory::createIndexBuffer(const uint32_t* indices,
+                                                           uint32_t        count) const
 {
     return tryMakeScoped<Vulkan::IndexBuffer>(m_device, indices, count);
 }
 
-Scoped<GE::VertexBuffer> GraphicsFactory::createVertexBuffer(uint32_t size,
-                                                             const void *vertices) const
+Scoped<GE::VertexBuffer> GraphicsFactory::createVertexBuffer(uint32_t    size,
+                                                             const void* vertices) const
 
 {
     return tryMakeScoped<Vulkan::VertexBuffer>(m_device, size, vertices);
@@ -69,8 +69,8 @@ Scoped<GE::StagingBuffer> GraphicsFactory::createStagingBuffer() const
     return tryMakeScoped<Vulkan::StagingBuffer>(m_device);
 }
 
-Scoped<GE::UniformBuffer> GraphicsFactory::createUniformBuffer(uint32_t size,
-                                                               const void *data) const
+Scoped<GE::UniformBuffer> GraphicsFactory::createUniformBuffer(uint32_t    size,
+                                                               const void* data) const
 {
     return tryMakeScoped<Vulkan::UniformBuffer>(m_device, size, data);
 }
@@ -80,7 +80,7 @@ Scoped<GE::Shader> GraphicsFactory::createShader(Shader::Type type)
     return tryMakeScoped<Vulkan::Shader>(m_device, type);
 }
 
-Scoped<GE::Texture> GraphicsFactory::createTexture(const texture_config_t &config)
+Scoped<GE::Texture> GraphicsFactory::createTexture(const texture_config_t& config)
 {
     switch (config.type) {
         case TextureType::TEXTURE_2D: return tryMakeScoped<Vulkan::Texture2D>(m_device, config);

--- a/src/genesis/graphics/vulkan/graphics_factory.h
+++ b/src/genesis/graphics/vulkan/graphics_factory.h
@@ -47,7 +47,7 @@ public:
     Scoped<GE::Framebuffer> createFramebuffer(const Framebuffer::config_t& config) const override;
 
     Scoped<GE::IndexBuffer> createIndexBuffer(const uint32_t* indices,
-                                              uint32_t count) const override;
+                                              uint32_t        count) const override;
     Scoped<GE::VertexBuffer> createVertexBuffer(uint32_t size, const void* vertices) const override;
     Scoped<GE::StagingBuffer> createStagingBuffer() const override;
     Scoped<GE::UniformBuffer> createUniformBuffer(uint32_t size, const void* data) const override;

--- a/src/genesis/graphics/vulkan/image.h
+++ b/src/genesis/graphics/vulkan/image.h
@@ -50,16 +50,16 @@ class Device;
 struct memory_barrier_config_t;
 
 struct image_config_t {
-    VkImageViewType view_type{VK_IMAGE_VIEW_TYPE_2D};
-    VkExtent3D extent{0, 0, 1};
-    uint32_t mip_levels{1};
-    uint32_t layers{1};
+    VkImageViewType       view_type{VK_IMAGE_VIEW_TYPE_2D};
+    VkExtent3D            extent{0, 0, 1};
+    uint32_t              mip_levels{1};
+    uint32_t              layers{1};
     VkSampleCountFlagBits samples{VK_SAMPLE_COUNT_1_BIT};
-    VkFormat format{};
-    VkImageTiling tiling{};
-    VkImageUsageFlags usage{};
+    VkFormat              format{};
+    VkImageTiling         tiling{};
+    VkImageUsageFlags     usage{};
     VkMemoryPropertyFlags memory_properties{};
-    VkImageAspectFlags aspect_mask{};
+    VkImageAspectFlags    aspect_mask{};
 };
 
 class Image
@@ -91,21 +91,21 @@ private:
     uint32_t getMemoryType(uint32_t type_filter, VkMemoryPropertyFlags properties);
 
     void transitionImageLayout(VkImageLayout new_layout);
-    void copyToImage(const GE::StagingBuffer& buffer,
+    void copyToImage(const GE::StagingBuffer&              buffer,
                      const std::vector<VkBufferImageCopy>& regions);
     void copyFromImage(const GE::StagingBuffer& buffer);
     void createMipmaps();
 
     Shared<Device> m_device;
 
-    VkImage m_image{VK_NULL_HANDLE};
+    VkImage        m_image{VK_NULL_HANDLE};
     VkDeviceMemory m_memory{VK_NULL_HANDLE};
-    VkImageView m_image_view{VK_NULL_HANDLE};
+    VkImageView    m_image_view{VK_NULL_HANDLE};
 
     VkExtent3D m_extent{};
-    VkFormat m_format{VK_FORMAT_UNDEFINED};
-    uint32_t m_mip_levels{};
-    uint32_t m_layers{};
+    VkFormat   m_format{VK_FORMAT_UNDEFINED};
+    uint32_t   m_mip_levels{};
+    uint32_t   m_layers{};
 };
 
 } // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/instance.cpp
+++ b/src/genesis/graphics/vulkan/instance.cpp
@@ -69,9 +69,11 @@ VkDebugUtilsMessageSeverityFlagsEXT debugMessageSeverity()
     return toDebugMessageSeverity(getEnv(GE::GRAPHICS_SEVERITY));
 }
 
-VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
-    VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type,
-    const VkDebugUtilsMessengerCallbackDataEXT* callback_data, [[maybe_unused]] void* user_data)
+VKAPI_ATTR VkBool32 VKAPI_CALL
+debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT      severity,
+              VkDebugUtilsMessageTypeFlagsEXT             type,
+              const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
+              [[maybe_unused]] void*                      user_data)
 {
     const char* type_str = "Unknown";
     const char* pattern = "[Vk {}]: {}";
@@ -133,7 +135,7 @@ void Instance::createInstance(void* native_window, std::string_view app_name)
 {
     GE_CORE_INFO("Creating Vulkan Instance...");
     auto* window = reinterpret_cast<SDL_Window*>(native_window);
-    auto window_extensions = vulkanGet<const char*>(::SDL_Vulkan_GetInstanceExtensions, window);
+    auto  window_extensions = vulkanGet<const char*>(::SDL_Vulkan_GetInstanceExtensions, window);
 
 #ifndef GE_DISABLE_DEBUG
     window_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
@@ -161,7 +163,7 @@ void Instance::createInstance(void* native_window, std::string_view app_name)
 #endif // GE_PLATFORM_APPLE
 
 #ifndef GE_DISABLE_DEBUG
-    auto debug_info = getDebugMsgrCreateInfo(debugMessageSeverity());
+    auto                       debug_info = getDebugMsgrCreateInfo(debugMessageSeverity());
     std::array<const char*, 1> validation_layers = {"VK_LAYER_KHRONOS_validation"};
 
     instance_info.ppEnabledLayerNames = validation_layers.data();

--- a/src/genesis/graphics/vulkan/instance.h
+++ b/src/genesis/graphics/vulkan/instance.h
@@ -64,7 +64,7 @@ private:
 
     void destroyVulkanHandles();
 
-    VkInstance m_instance{VK_NULL_HANDLE};
+    VkInstance               m_instance{VK_NULL_HANDLE};
     VkDebugUtilsMessengerEXT m_debug_utils{VK_NULL_HANDLE};
 };
 

--- a/src/genesis/graphics/vulkan/pipeline.cpp
+++ b/src/genesis/graphics/vulkan/pipeline.cpp
@@ -355,7 +355,8 @@ void Pipeline::createPipeline(Vulkan::pipeline_config_t config)
     }
 }
 
-void Pipeline::bindResource(GPUCommandQueue* queue, const std::string& name,
+void Pipeline::bindResource(GPUCommandQueue*      queue,
+                            const std::string&    name,
                             VkWriteDescriptorSet* write_descriptor_set)
 {
     auto resource = m_resources->resource(name);
@@ -395,8 +396,9 @@ void Pipeline::pushConstantIfValid(GPUCommandQueue* queue, const std::string& na
 }
 
 template<typename T>
-void Pipeline::pushConstantCmd(GPUCommandQueue* queue, const push_constant_t& push_constant,
-                               T value)
+void Pipeline::pushConstantCmd(GPUCommandQueue*       queue,
+                               const push_constant_t& push_constant,
+                               T                      value)
 {
     queue->enqueue([this, &push_constant, value](void* cmd_buffer) {
         vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,
@@ -406,8 +408,9 @@ void Pipeline::pushConstantCmd(GPUCommandQueue* queue, const push_constant_t& pu
 }
 
 template<>
-void Pipeline::pushConstantCmd<bool>(GPUCommandQueue* queue, const push_constant_t& push_constant,
-                                     bool value)
+void Pipeline::pushConstantCmd<bool>(GPUCommandQueue*       queue,
+                                     const push_constant_t& push_constant,
+                                     bool                   value)
 {
     queue->enqueue([this, &push_constant, vk_value = toVkBool(value)](void* cmd_buffer) {
         vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,
@@ -417,8 +420,9 @@ void Pipeline::pushConstantCmd<bool>(GPUCommandQueue* queue, const push_constant
 }
 
 template<>
-void Pipeline::pushConstantCmd<const Vec2&>(GPUCommandQueue* queue,
-                                            const push_constant_t& push_constant, const Vec2& value)
+void Pipeline::pushConstantCmd<const Vec2&>(GPUCommandQueue*       queue,
+                                            const push_constant_t& push_constant,
+                                            const Vec2&            value)
 {
     queue->enqueue([this, &push_constant, &value](void* cmd_buffer) {
         vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,
@@ -428,8 +432,9 @@ void Pipeline::pushConstantCmd<const Vec2&>(GPUCommandQueue* queue,
 }
 
 template<>
-void Pipeline::pushConstantCmd<const Vec3&>(GPUCommandQueue* queue,
-                                            const push_constant_t& push_constant, const Vec3& value)
+void Pipeline::pushConstantCmd<const Vec3&>(GPUCommandQueue*       queue,
+                                            const push_constant_t& push_constant,
+                                            const Vec3&            value)
 {
     queue->enqueue([this, &push_constant, &value](void* cmd_buffer) {
         vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,
@@ -439,8 +444,9 @@ void Pipeline::pushConstantCmd<const Vec3&>(GPUCommandQueue* queue,
 }
 
 template<>
-void Pipeline::pushConstantCmd<const Vec4&>(GPUCommandQueue* queue,
-                                            const push_constant_t& push_constant, const Vec4& value)
+void Pipeline::pushConstantCmd<const Vec4&>(GPUCommandQueue*       queue,
+                                            const push_constant_t& push_constant,
+                                            const Vec4&            value)
 {
     queue->enqueue([this, &push_constant, &value](void* cmd_buffer) {
         vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,
@@ -450,8 +456,9 @@ void Pipeline::pushConstantCmd<const Vec4&>(GPUCommandQueue* queue,
 }
 
 template<>
-void Pipeline::pushConstantCmd<const Mat4&>(GPUCommandQueue* queue,
-                                            const push_constant_t& push_constant, const Mat4& value)
+void Pipeline::pushConstantCmd<const Mat4&>(GPUCommandQueue*       queue,
+                                            const push_constant_t& push_constant,
+                                            const Mat4&            value)
 {
     queue->enqueue([this, &push_constant, &value](void* cmd_buffer) {
         vkCmdPushConstants(toVkCommandBuffer(cmd_buffer), m_pipeline_layout,

--- a/src/genesis/graphics/vulkan/pipeline.h
+++ b/src/genesis/graphics/vulkan/pipeline.h
@@ -57,7 +57,8 @@ public:
     ~Pipeline();
 
     void bind(GPUCommandQueue* queue) override;
-    void bind(GPUCommandQueue* queue, const std::string& name,
+    void bind(GPUCommandQueue*         queue,
+              const std::string&       name,
               const GE::UniformBuffer& ubo) override;
     void bind(GPUCommandQueue* queue, const std::string& name, const GE::Texture& texture) override;
 
@@ -79,7 +80,8 @@ private:
     void createPipelineLayout();
     void createPipeline(Vulkan::pipeline_config_t config);
 
-    void bindResource(GPUCommandQueue* queue, const std::string& name,
+    void bindResource(GPUCommandQueue*      queue,
+                      const std::string&    name,
                       VkWriteDescriptorSet* write_descriptor_set);
 
     template<typename T>
@@ -89,9 +91,9 @@ private:
 
     void destroyVkHandles();
 
-    Shared<Device> m_device;
-    VkPipeline m_pipeline{VK_NULL_HANDLE};
-    VkPipelineLayout m_pipeline_layout{VK_NULL_HANDLE};
+    Shared<Device>            m_device;
+    VkPipeline                m_pipeline{VK_NULL_HANDLE};
+    VkPipelineLayout          m_pipeline_layout{VK_NULL_HANDLE};
     Scoped<PipelineResources> m_resources;
 };
 

--- a/src/genesis/graphics/vulkan/pipeline_barrier.cpp
+++ b/src/genesis/graphics/vulkan/pipeline_barrier.cpp
@@ -34,8 +34,10 @@
 
 namespace GE::Vulkan {
 
-void PipelineBarrier::submit(VkCommandBuffer cmd, const std::vector<VkImageMemoryBarrier> &barriers,
-                             VkPipelineStageFlagBits src_stage, VkPipelineStageFlagBits dst_stage)
+void PipelineBarrier::submit(VkCommandBuffer                          cmd,
+                             const std::vector<VkImageMemoryBarrier>& barriers,
+                             VkPipelineStageFlagBits                  src_stage,
+                             VkPipelineStageFlagBits                  dst_stage)
 {
     vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr, barriers.size(),
                          barriers.data());

--- a/src/genesis/graphics/vulkan/pipeline_barrier.h
+++ b/src/genesis/graphics/vulkan/pipeline_barrier.h
@@ -40,8 +40,10 @@ namespace GE::Vulkan {
 class PipelineBarrier
 {
 public:
-    static void submit(VkCommandBuffer cmd, const std::vector<VkImageMemoryBarrier>& barriers,
-                       VkPipelineStageFlagBits src_stage, VkPipelineStageFlagBits dst_stage);
+    static void submit(VkCommandBuffer                          cmd,
+                       const std::vector<VkImageMemoryBarrier>& barriers,
+                       VkPipelineStageFlagBits                  src_stage,
+                       VkPipelineStageFlagBits                  dst_stage);
 };
 
 constexpr VkImageAspectFlags toVkAspect(VkFormat format)

--- a/src/genesis/graphics/vulkan/pipeline_config.h
+++ b/src/genesis/graphics/vulkan/pipeline_config.h
@@ -41,20 +41,22 @@ namespace GE::Vulkan {
 class DescriptorPool;
 
 struct pipeline_config_t: GE::pipeline_config_t {
-    VkPipelineCache pipeline_cache{VK_NULL_HANDLE};
-    std::vector<VkFormat> color_formats{VK_FORMAT_UNDEFINED};
-    VkFormat depth_format{VK_FORMAT_UNDEFINED};
-    VkFrontFace front_face{VK_FRONT_FACE_COUNTER_CLOCKWISE};
-    VkSampleCountFlagBits msaa_samples{VK_SAMPLE_COUNT_1_BIT};
-    Shared<DescriptorPool> descriptor_pool{}; // NOLINT(readability-redundant-member-init)
+    VkPipelineCache        pipeline_cache{VK_NULL_HANDLE};
+    std::vector<VkFormat>  color_formats{VK_FORMAT_UNDEFINED};
+    VkFormat               depth_format{VK_FORMAT_UNDEFINED};
+    VkFrontFace            front_face{VK_FRONT_FACE_COUNTER_CLOCKWISE};
+    VkSampleCountFlagBits  msaa_samples{VK_SAMPLE_COUNT_1_BIT};
+    // NOLINTNEXTLINE(readability-redundant-member-init)
+    Shared<DescriptorPool> descriptor_pool{};
 
-    VkPipelineViewportStateCreateInfo viewport_state{};
+    VkPipelineViewportStateCreateInfo      viewport_state{};
     VkPipelineInputAssemblyStateCreateInfo input_assembly_state{};
     VkPipelineRasterizationStateCreateInfo rasterization_state{};
-    VkPipelineMultisampleStateCreateInfo multisample_state{};
-    VkPipelineDepthStencilStateCreateInfo depth_stencil_state{};
-    std::vector<VkDynamicState> dynamic_state_list{}; // NOLINT(readability-redundant-member-init)
-    VkPipelineDynamicStateCreateInfo dynamic_state{};
+    VkPipelineMultisampleStateCreateInfo   multisample_state{};
+    VkPipelineDepthStencilStateCreateInfo  depth_stencil_state{};
+    // NOLINTNEXTLINE(readability-redundant-member-init)
+    std::vector<VkDynamicState>            dynamic_state_list{};
+    VkPipelineDynamicStateCreateInfo       dynamic_state{};
 };
 
 VkBlendFactor toVkBlendFactor(BlendFactor factor);

--- a/src/genesis/graphics/vulkan/pipeline_resources.cpp
+++ b/src/genesis/graphics/vulkan/pipeline_resources.cpp
@@ -81,7 +81,7 @@ uint32_t maxSetValue(const GE::Vulkan::PipelineResources::Resources& descriptor_
 
 namespace GE::Vulkan {
 
-PipelineResources::PipelineResources(Shared<Device> device,
+PipelineResources::PipelineResources(Shared<Device>                   device,
                                      const Vulkan::pipeline_config_t& pipeline_config)
     : m_device{std::move(device)}
     , m_descriptor_pool{pipeline_config.descriptor_pool}
@@ -110,7 +110,7 @@ std::optional<resource_descriptor_t> PipelineResources::resource(const std::stri
 
 VkDescriptorSet PipelineResources::descriptorSet(const resource_descriptor_t& set_descriptor)
 {
-    auto* set_layout = m_descriptor_set_layouts[set_descriptor.set];
+    auto*    set_layout = m_descriptor_set_layouts[set_descriptor.set];
     uint32_t binding = set_descriptor.binding;
 
     // This is a hack to reuse descriptor sets created for multi-binded resources. That
@@ -180,7 +180,7 @@ PipelineResources::createSetLayoutBindings(const Resources& descriptor_resources
 }
 
 void PipelineResources::updatePushConstants(VkShaderStageFlagBits shader_stage,
-                                            const PushConstants& push_constants)
+                                            const PushConstants&  push_constants)
 {
     for (const auto& push_constant : push_constants) {
         const auto& name = push_constant.name;

--- a/src/genesis/graphics/vulkan/pipeline_resources.h
+++ b/src/genesis/graphics/vulkan/pipeline_resources.h
@@ -78,17 +78,17 @@ private:
     void createDescriptorSetLayouts(const Vulkan::pipeline_config_t& pipeline_config);
     SetLayoutBindings createSetLayoutBindings(const Resources& descriptor_resources);
     void updatePushConstants(VkShaderStageFlagBits shader_stage,
-                             const PushConstants& push_constants);
+                             const PushConstants&  push_constants);
     void createPushConstantRanges();
 
     void destroyVkHandles();
 
-    Shared<Device> m_device;
-    Shared<DescriptorPool> m_descriptor_pool;
-    DescriptorSetLayouts m_descriptor_set_layouts;
-    PushConstantRanges m_push_constant_ranges;
+    Shared<Device>                                         m_device;
+    Shared<DescriptorPool>                                 m_descriptor_pool;
+    DescriptorSetLayouts                                   m_descriptor_set_layouts;
+    PushConstantRanges                                     m_push_constant_ranges;
     std::unordered_map<std::string, resource_descriptor_t> m_resources;
-    std::unordered_map<std::string, push_constant_t> m_push_constants;
+    std::unordered_map<std::string, push_constant_t>       m_push_constants;
 };
 
 constexpr VkDescriptorType toVkDescriptorType(resource_descriptor_t::Type type)

--- a/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.h
+++ b/src/genesis/graphics/vulkan/renderers/framebuffer_renderer.h
@@ -42,18 +42,18 @@ class Framebuffer;
 class FramebufferRenderer: public RendererBase
 {
 public:
-    FramebufferRenderer(Shared<Device> device, Vulkan::Framebuffer *framebuffer);
+    FramebufferRenderer(Shared<Device> device, Vulkan::Framebuffer* framebuffer);
     ~FramebufferRenderer();
 
     bool beginFrame(ClearMode clear_mode = CLEAR_ALL) override;
     void endFrame() override;
     void swapBuffers() override;
 
-    void onEvent([[maybe_unused]] Event *event) override {};
+    void onEvent([[maybe_unused]] Event* event) override {};
 
     Vec2 size() const override;
 
-    Scoped<GE::Pipeline> createPipeline(const pipeline_config_t &config) override;
+    Scoped<GE::Pipeline> createPipeline(const pipeline_config_t& config) override;
 
 private:
     void createSyncObjects();
@@ -68,13 +68,13 @@ private:
     VkExtent2D extent() const override;
     VkViewport viewport() const override;
 
-    const std::vector<VkRenderingAttachmentInfo> &
+    const std::vector<VkRenderingAttachmentInfo>&
     colorRenderingAttachments(ClearMode clear_mode) override;
     std::optional<VkRenderingAttachmentInfo>
     depthRenderingAttachment(ClearMode clear_mode) override;
 
-    Vulkan::Framebuffer *m_framebuffer{nullptr};
-    VkFence m_in_flight_fence{VK_NULL_HANDLE};
+    Vulkan::Framebuffer* m_framebuffer{nullptr};
+    VkFence              m_in_flight_fence{VK_NULL_HANDLE};
 };
 
 } // namespace GE::Vulkan

--- a/src/genesis/graphics/vulkan/renderers/renderer_base.cpp
+++ b/src/genesis/graphics/vulkan/renderers/renderer_base.cpp
@@ -152,8 +152,11 @@ bool RendererBase::endRendering()
     return true;
 }
 
-void RendererBase::draw(GPUCommandQueue* queue, uint32_t vertex_count, uint32_t instance_count,
-                        uint32_t first_vertex, uint32_t first_instance)
+void RendererBase::draw(GPUCommandQueue* queue,
+                        uint32_t         vertex_count,
+                        uint32_t         instance_count,
+                        uint32_t         first_vertex,
+                        uint32_t         first_instance)
 {
     queue->enqueue([vertex_count, instance_count, first_vertex, first_instance](void* cmd) {
         vkCmdDraw(toVkCommandBuffer(cmd), vertex_count, instance_count, first_vertex,

--- a/src/genesis/graphics/vulkan/renderers/renderer_base.h
+++ b/src/genesis/graphics/vulkan/renderers/renderer_base.h
@@ -64,8 +64,11 @@ protected:
     void updateDynamicState();
     bool endRendering();
 
-    void draw(GPUCommandQueue* queue, uint32_t vertex_count, uint32_t instance_count,
-              uint32_t first_vertex, uint32_t first_instance) override;
+    void draw(GPUCommandQueue* queue,
+              uint32_t         vertex_count,
+              uint32_t         instance_count,
+              uint32_t         first_vertex,
+              uint32_t         first_instance) override;
 
     virtual void transitImageLayoutBeforeRendering(VkCommandBuffer cmd) = 0;
     virtual void transitImageLayoutAfterRendering(VkCommandBuffer cmd) = 0;
@@ -81,9 +84,9 @@ protected:
 
     Shared<Device> m_device;
 
-    VkPipelineCache m_pipeline_cache{VK_NULL_HANDLE};
-    VkCommandPool m_command_pool{VK_NULL_HANDLE};
-    Shared<DescriptorPool> m_descriptor_pool;
+    VkPipelineCache              m_pipeline_cache{VK_NULL_HANDLE};
+    VkCommandPool                m_command_pool{VK_NULL_HANDLE};
+    Shared<DescriptorPool>       m_descriptor_pool;
     std::vector<VkCommandBuffer> m_cmd_buffers;
 
     RenderCommand m_render_command{this};

--- a/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
+++ b/src/genesis/graphics/vulkan/renderers/window_renderer.cpp
@@ -245,7 +245,7 @@ VkViewport WindowRenderer::viewport() const
 const std::vector<VkRenderingAttachmentInfo>&
 WindowRenderer::colorRenderingAttachments(ClearMode clear_mode)
 {
-    bool should_clear = clear_mode == CLEAR_COLOR || clear_mode == CLEAR_ALL;
+    bool  should_clear = clear_mode == CLEAR_COLOR || clear_mode == CLEAR_ALL;
     auto& color_attachment = m_color_rendering_attachments[0];
 
     if (m_msaa_samples > 1) {

--- a/src/genesis/graphics/vulkan/renderers/window_renderer.h
+++ b/src/genesis/graphics/vulkan/renderers/window_renderer.h
@@ -53,8 +53,8 @@ class WindowRenderer: public RendererBase
 public:
     struct config_t {
         VkSurfaceKHR surface{VK_NULL_HANDLE};
-        Vec2 window_size{0.0f, 0.0f};
-        uint8_t msaa_samples{1};
+        Vec2         window_size{0.0f, 0.0f};
+        uint8_t      msaa_samples{1};
     };
 
     WindowRenderer(Shared<Device> device, const config_t& config);
@@ -90,13 +90,13 @@ private:
     depthRenderingAttachment(ClearMode clear_mode) override;
 
     VkSurfaceKHR m_surface{VK_NULL_HANDLE};
-    Vec2 m_window_size{0.0f, 0.0f};
-    uint8_t m_msaa_samples{1};
+    Vec2         m_window_size{0.0f, 0.0f};
+    uint8_t      m_msaa_samples{1};
 
     std::vector<VkRenderingAttachmentInfo> m_color_rendering_attachments;
-    VkRenderingAttachmentInfo m_depth_rendering_attachment{};
+    VkRenderingAttachmentInfo              m_depth_rendering_attachment{};
 
-    bool m_is_framebuffer_resized{false};
+    bool              m_is_framebuffer_resized{false};
     Scoped<SwapChain> m_swap_chain;
 };
 

--- a/src/genesis/graphics/vulkan/sdl_gui_context.cpp
+++ b/src/genesis/graphics/vulkan/sdl_gui_context.cpp
@@ -53,8 +53,8 @@ namespace {
 
 void mapKeys()
 {
-    auto &io = ImGui::GetIO();
-    auto cast_key = [](GE::KeyCode key) { return static_cast<int>(key); };
+    auto& io = ImGui::GetIO();
+    auto  cast_key = [](GE::KeyCode key) { return static_cast<int>(key); };
 
     io.KeyMap[ImGuiKey_Tab] = cast_key(GE::KeyCode::TAB);
     io.KeyMap[ImGuiKey_LeftArrow] = cast_key(GE::KeyCode::LEFT);
@@ -84,7 +84,7 @@ void mapKeys()
 
 namespace GE::Vulkan::SDL {
 
-GUIContext::GUIContext(void *window, Shared<Device> device, WindowRenderer *window_renderer)
+GUIContext::GUIContext(void* window, Shared<Device> device, WindowRenderer* window_renderer)
     : m_device{std::move(device)}
     , m_event_handler{makeScoped<Vulkan::SDL::EventHandler>()}
 {
@@ -93,7 +93,7 @@ GUIContext::GUIContext(void *window, Shared<Device> device, WindowRenderer *wind
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
 
-    ImGuiIO &io = ImGui::GetIO();
+    ImGuiIO& io = ImGui::GetIO();
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
@@ -102,12 +102,12 @@ GUIContext::GUIContext(void *window, Shared<Device> device, WindowRenderer *wind
     ImGui::StyleColorsDark();
 
     if (isDockingEnabled()) {
-        ImGuiStyle &style = ImGui::GetStyle();
+        ImGuiStyle& style = ImGui::GetStyle();
         style.WindowRounding = 0.0f;
         style.Colors[ImGuiCol_WindowBg].w = 1.0f;
     }
 
-    auto *sdl_window = reinterpret_cast<SDL_Window *>(window);
+    auto* sdl_window = reinterpret_cast<SDL_Window*>(window);
 
     if (!ImGui_ImplSDL2_InitForVulkan(sdl_window)) {
         throw Vulkan::Exception{"Failed to initialize SDL2 for Vulkan"};
@@ -115,7 +115,7 @@ GUIContext::GUIContext(void *window, Shared<Device> device, WindowRenderer *wind
 
     createDescriptorPool();
 
-    auto *swap_chain = window_renderer->swapChain();
+    auto* swap_chain = window_renderer->swapChain();
 
     std::array<VkFormat, 1> color_formats{swap_chain->colorFormat()};
 
@@ -179,14 +179,14 @@ void GUIContext::end()
     }
 }
 
-void GUIContext::draw(GPUCommandQueue *queue)
+void GUIContext::draw(GPUCommandQueue* queue)
 {
-    queue->enqueue([](void *cmd) {
+    queue->enqueue([](void* cmd) {
         ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), toVkCommandBuffer(cmd));
     });
 }
 
-GUI::EventHandler *GUIContext::eventHandler()
+GUI::EventHandler* GUIContext::eventHandler()
 {
     return m_event_handler.get();
 }
@@ -238,7 +238,7 @@ bool GUIContext::isViewportEnabled() const
     return (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable) != 0;
 }
 
-VkDescriptorSet createGuiTextureID(const Vulkan::Texture &texture)
+VkDescriptorSet createGuiTextureID(const Vulkan::Texture& texture)
 {
     static constexpr VkImageLayout image_layout{VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
     return ::ImGui_ImplVulkan_AddTexture(texture.sampler(), texture.image()->view(), image_layout);

--- a/src/genesis/graphics/vulkan/sdl_gui_context.h
+++ b/src/genesis/graphics/vulkan/sdl_gui_context.h
@@ -66,9 +66,9 @@ private:
     bool isDockingEnabled() const;
     bool isViewportEnabled() const;
 
-    Shared<Device> m_device;
+    Shared<Device>                    m_device;
     Scoped<Vulkan::SDL::EventHandler> m_event_handler;
-    VkDescriptorPool m_descriptor_pool{VK_NULL_HANDLE};
+    VkDescriptorPool                  m_descriptor_pool{VK_NULL_HANDLE};
 };
 
 VkDescriptorSet createGuiTextureID(const Vulkan::Texture& texture);

--- a/src/genesis/graphics/vulkan/sdl_gui_event_handler.cpp
+++ b/src/genesis/graphics/vulkan/sdl_gui_event_handler.cpp
@@ -43,7 +43,7 @@ namespace {
 bool onKeyEvent(const GE::KeyEvent& event, bool is_pressed)
 {
     auto& io = ImGui::GetIO();
-    int key = static_cast<int>(event.getCode());
+    int   key = static_cast<int>(event.getCode());
 
     io.KeysDown[key] = is_pressed;
     io.KeyShift = (event.getMod() & GE::KeyModFlags::SHIFT_BIT) != 0;
@@ -109,7 +109,7 @@ bool EventHandler::onMouseButtonReleasedEvent(const MouseButtonReleasedEvent& ev
 bool EventHandler::onMouseMovedEvent(const MouseMovedEvent& event)
 {
     auto& io = ImGui::GetIO();
-    auto mouse_pos = event.getPosition();
+    auto  mouse_pos = event.getPosition();
 
     if ((io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) != 0) {
         mouse_pos += Application::window()->position();

--- a/src/genesis/graphics/vulkan/sdl_gui_event_handler.h
+++ b/src/genesis/graphics/vulkan/sdl_gui_event_handler.h
@@ -39,22 +39,22 @@ namespace GE::Vulkan::SDL {
 class GE_API EventHandler: public GE::GUI::EventHandler
 {
 public:
-    bool onKeyPressedEvent(const KeyPressedEvent &event) override;
-    bool onKeyReleasedEvent(const KeyReleasedEvent &event) override;
-    bool onKeyTypedEvent(const KeyTypedEvent &event) override;
+    bool onKeyPressedEvent(const KeyPressedEvent& event) override;
+    bool onKeyReleasedEvent(const KeyReleasedEvent& event) override;
+    bool onKeyTypedEvent(const KeyTypedEvent& event) override;
 
-    bool onMouseButtonPressedEvent(const MouseButtonPressedEvent &event) override;
-    bool onMouseButtonReleasedEvent(const MouseButtonReleasedEvent &event) override;
-    bool onMouseMovedEvent(const MouseMovedEvent &event) override;
-    bool onMouseScrolledEvent(const MouseScrolledEvent &event) override;
+    bool onMouseButtonPressedEvent(const MouseButtonPressedEvent& event) override;
+    bool onMouseButtonReleasedEvent(const MouseButtonReleasedEvent& event) override;
+    bool onMouseMovedEvent(const MouseMovedEvent& event) override;
+    bool onMouseScrolledEvent(const MouseScrolledEvent& event) override;
 
-    bool onWindowMovedEvent(const WindowMovedEvent &event) override;
-    bool onWindowResizedEvent(const WindowResizedEvent &event) override;
-    bool onWindowEnteredEvent(const WindowEnteredEvent &event) override;
-    bool onWindowLeftEvent(const WindowLeftEvent &event) override;
-    bool onWindowFocusGainedEvent(const WindowFocusGainedEvent &event) override;
-    bool onWindowFocusLostEvent(const WindowFocusLostEvent &event) override;
-    bool onWindowClosedEvent(const WindowClosedEvent &event) override;
+    bool onWindowMovedEvent(const WindowMovedEvent& event) override;
+    bool onWindowResizedEvent(const WindowResizedEvent& event) override;
+    bool onWindowEnteredEvent(const WindowEnteredEvent& event) override;
+    bool onWindowLeftEvent(const WindowLeftEvent& event) override;
+    bool onWindowFocusGainedEvent(const WindowFocusGainedEvent& event) override;
+    bool onWindowFocusLostEvent(const WindowFocusLostEvent& event) override;
+    bool onWindowClosedEvent(const WindowClosedEvent& event) override;
 };
 
 } // namespace GE::Vulkan::SDL

--- a/src/genesis/graphics/vulkan/shader.h
+++ b/src/genesis/graphics/vulkan/shader.h
@@ -46,33 +46,33 @@ public:
     Shader(Shared<Device> device, Type type);
     ~Shader();
 
-    bool compileFromFile(const std::string &filepath) override;
-    bool compileFromSource(const std::string &source_code) override;
+    bool compileFromFile(const std::string& filepath) override;
+    bool compileFromSource(const std::string& source_code) override;
 
     Type type() const override { return m_type; }
-    void *nativeHandle() const override { return m_shader_module; }
-    const ShaderInputLayout &inputLayout() const override { return m_input_layout; }
+    void* nativeHandle() const override { return m_shader_module; }
+    const ShaderInputLayout& inputLayout() const override { return m_input_layout; }
 
-    const ResourceDescriptors &resourceDescriptors() const override
+    const ResourceDescriptors& resourceDescriptors() const override
     {
         return m_resource_descriptors;
     }
 
-    const PushConstants &pushConstants() const override { return m_push_constants; }
+    const PushConstants& pushConstants() const override { return m_push_constants; }
 
 private:
-    bool compileFromFileOrSource(const std::string &filepath, const std::string &source_code);
-    bool createShaderModule(const std::vector<uint32_t> &shader_code);
+    bool compileFromFileOrSource(const std::string& filepath, const std::string& source_code);
+    bool createShaderModule(const std::vector<uint32_t>& shader_code);
 
-    Shared<Device> m_device;
-    Type m_type{Type::NONE};
-    VkShaderModule m_shader_module{VK_NULL_HANDLE};
-    ShaderInputLayout m_input_layout;
+    Shared<Device>      m_device;
+    Type                m_type{Type::NONE};
+    VkShaderModule      m_shader_module{VK_NULL_HANDLE};
+    ShaderInputLayout   m_input_layout;
     ResourceDescriptors m_resource_descriptors;
-    PushConstants m_push_constants;
+    PushConstants       m_push_constants;
 };
 
-inline VkShaderModule toVkShaderModule(const GE::Shader &shader)
+inline VkShaderModule toVkShaderModule(const GE::Shader& shader)
 {
     return reinterpret_cast<VkShaderModule>(shader.nativeHandle());
 }

--- a/src/genesis/graphics/vulkan/single_command.h
+++ b/src/genesis/graphics/vulkan/single_command.h
@@ -62,8 +62,8 @@ private:
 
     VkQueue getQueue(QueueFamily family);
 
-    Shared<Device> m_device;
-    QueueFamily m_queue_family{QUEUE_UNKNOWN};
+    Shared<Device>  m_device;
+    QueueFamily     m_queue_family{QUEUE_UNKNOWN};
     VkCommandBuffer m_cmd_buffer{VK_NULL_HANDLE};
 };
 

--- a/src/genesis/graphics/vulkan/swap_chain.cpp
+++ b/src/genesis/graphics/vulkan/swap_chain.cpp
@@ -44,7 +44,7 @@
 namespace {
 
 constexpr uint64_t VULKAN_TIMEOUT_NONE = std::numeric_limits<uint64_t>::max();
-constexpr size_t MAX_FRAMES_IN_FLIGHT{3};
+constexpr size_t   MAX_FRAMES_IN_FLIGHT{3};
 
 uint32_t imageCountFromCaps(const VkSurfaceCapabilitiesKHR& capabilities)
 {
@@ -201,8 +201,8 @@ void SwapChain::createSwapChain(VkSwapchainKHR old_swap_chain, const Vec2& windo
     VkDevice device = m_device->device();
 
     const auto& swap_chain_details = m_device->swapChainDetails();
-    auto surface_format = chooseSurfaceFormat(swap_chain_details.formats);
-    auto present_mode = choosePresentMode(swap_chain_details.present_mode);
+    auto        surface_format = chooseSurfaceFormat(swap_chain_details.formats);
+    auto        present_mode = choosePresentMode(swap_chain_details.present_mode);
     m_extent = chooseSwapExtent(swap_chain_details.capabilities, window_size);
     m_min_image_count = imageCountFromCaps(swap_chain_details.capabilities);
 
@@ -221,7 +221,7 @@ void SwapChain::createSwapChain(VkSwapchainKHR old_swap_chain, const Vec2& windo
     create_info.clipped = VK_TRUE;
     create_info.oldSwapchain = old_swap_chain;
 
-    const auto& indices = m_device->queueIndices();
+    const auto&             indices = m_device->queueIndices();
     std::array<uint32_t, 2> queue_family_indices = {indices.graphics_family.value(),
                                                     indices.present_family.value()};
 
@@ -354,8 +354,10 @@ void SwapChain::destroyVkHandles()
     m_device.reset();
 }
 
-VkImageView SwapChain::createImageView(VkImage image, VkFormat format,
-                                       VkImageAspectFlags aspect_flags, uint32_t mip_levels)
+VkImageView SwapChain::createImageView(VkImage            image,
+                                       VkFormat           format,
+                                       VkImageAspectFlags aspect_flags,
+                                       uint32_t           mip_levels)
 {
     VkImageView image_view{VK_NULL_HANDLE};
 
@@ -378,7 +380,7 @@ VkImageView SwapChain::createImageView(VkImage image, VkFormat format,
 }
 
 VkExtent2D SwapChain::chooseSwapExtent(const VkSurfaceCapabilitiesKHR& capabilities,
-                                       const Vec2& window_size) const
+                                       const Vec2&                     window_size) const
 {
     if (capabilities.currentExtent.width != std::numeric_limits<uint32_t>::max()) {
         return capabilities.currentExtent;

--- a/src/genesis/graphics/vulkan/swap_chain.h
+++ b/src/genesis/graphics/vulkan/swap_chain.h
@@ -49,8 +49,8 @@ class SwapChain
 public:
     struct options_t {
         VkSurfaceKHR surface{VK_NULL_HANDLE};
-        Vec2 window_size{0.0f, 0.0f};
-        uint8_t msaa_samples{1};
+        Vec2         window_size{0.0f, 0.0f};
+        uint8_t      msaa_samples{1};
     };
 
     SwapChain(Shared<Vulkan::Device> device, const options_t& options);
@@ -93,17 +93,19 @@ private:
     void destroySwapChain(VkSwapchainKHR swap_chain);
     void destroyVkHandles();
 
-    VkImageView createImageView(VkImage image, VkFormat format, VkImageAspectFlags aspect_flags,
-                                uint32_t mip_levels);
+    VkImageView createImageView(VkImage            image,
+                                VkFormat           format,
+                                VkImageAspectFlags aspect_flags,
+                                uint32_t           mip_levels);
     VkExtent2D chooseSwapExtent(const VkSurfaceCapabilitiesKHR& capabilities,
-                                const Vec2& window_size) const;
+                                const Vec2&                     window_size) const;
 
     Shared<Vulkan::Device> m_device;
-    VkSurfaceKHR m_surface{VK_NULL_HANDLE};
-    uint8_t m_msaa_samples{1};
+    VkSurfaceKHR           m_surface{VK_NULL_HANDLE};
+    uint8_t                m_msaa_samples{1};
 
-    VkSwapchainKHR m_swap_chain{VK_NULL_HANDLE};
-    std::vector<VkImage> m_swap_chain_images;
+    VkSwapchainKHR           m_swap_chain{VK_NULL_HANDLE};
+    std::vector<VkImage>     m_swap_chain_images;
     std::vector<VkImageView> m_swap_chain_image_views;
 
     uint32_t m_min_image_count{0};
@@ -115,11 +117,11 @@ private:
 
     std::vector<VkSemaphore> m_image_available_semaphores;
     std::vector<VkSemaphore> m_render_finished_semaphores;
-    std::vector<VkFence> m_in_flight_fences;
-    std::vector<VkFence> m_images_in_flight;
+    std::vector<VkFence>     m_in_flight_fences;
+    std::vector<VkFence>     m_images_in_flight;
 
-    VkFormat m_image_format{VK_FORMAT_UNDEFINED};
-    VkFormat m_depth_format{VK_FORMAT_UNDEFINED};
+    VkFormat   m_image_format{VK_FORMAT_UNDEFINED};
+    VkFormat   m_depth_format{VK_FORMAT_UNDEFINED};
     VkExtent2D m_extent{};
 };
 

--- a/src/genesis/graphics/vulkan/texture.h
+++ b/src/genesis/graphics/vulkan/texture.h
@@ -61,10 +61,10 @@ protected:
     Shared<Device> m_device;
 
     Scoped<Image> m_image;
-    Vec2 m_size{0.0f, 0.0f};
+    Vec2          m_size{0.0f, 0.0f};
     TextureFormat m_format{TextureFormat::UNKNOWN};
-    bool m_is_opaque{true};
-    VkSampler m_sampler{VK_NULL_HANDLE};
+    bool          m_is_opaque{true};
+    VkSampler     m_sampler{VK_NULL_HANDLE};
 
     mutable VkDescriptorSet m_descriptor_set{VK_NULL_HANDLE};
 

--- a/src/genesis/graphics/vulkan/utils.h
+++ b/src/genesis/graphics/vulkan/utils.h
@@ -62,17 +62,17 @@ VkResult loadInstanceFuncAndCall(const char* func_name, VkInstance instance, Arg
     return VK_SUCCESS;
 }
 
-inline VkResult createDebugUtilsMessengerEXT(VkInstance instance,
+inline VkResult createDebugUtilsMessengerEXT(VkInstance                                instance,
                                              const VkDebugUtilsMessengerCreateInfoEXT* create_info,
-                                             const VkAllocationCallbacks* allocator,
+                                             const VkAllocationCallbacks*              allocator,
                                              VkDebugUtilsMessengerEXT* debug_messenger)
 {
     return loadInstanceFuncAndCall<PFN_vkCreateDebugUtilsMessengerEXT>(
         "vkCreateDebugUtilsMessengerEXT", instance, create_info, allocator, debug_messenger);
 }
 
-inline void destroyDebugUtilsMessengerEXT(VkInstance instance,
-                                          VkDebugUtilsMessengerEXT debug_messenger,
+inline void destroyDebugUtilsMessengerEXT(VkInstance                   instance,
+                                          VkDebugUtilsMessengerEXT     debug_messenger,
                                           const VkAllocationCallbacks* allocator)
 {
     loadInstanceFuncAndCall<PFN_vkDestroyDebugUtilsMessengerEXT>(

--- a/src/genesis/gui/base_layer.cpp
+++ b/src/genesis/gui/base_layer.cpp
@@ -42,7 +42,7 @@ namespace GE::GUI {
 
 void BaseLayer::onEvent(Event* event)
 {
-    auto* handler = Graphics::gui()->eventHandler();
+    auto*           handler = Graphics::gui()->eventHandler();
     EventDispatcher dispatcher{event};
 
     dispatcher.dispatch<KeyPressedEvent>(toEventHandler(&EventHandler::onKeyPressedEvent, handler));

--- a/src/genesis/gui/file_dialog.cpp
+++ b/src/genesis/gui/file_dialog.cpp
@@ -57,7 +57,7 @@ namespace GE::GUI {
 void FileDialog::showSingleFile(std::string_view default_path, std::string_view filter_list)
 {
     ::nfdchar_t* output_path{nullptr};
-    Defer output_path_defer{[output_path] { std::free(output_path); }};
+    Defer        output_path_defer{[output_path] { std::free(output_path); }};
 
     auto result = ::NFD_OpenDialog(filter_list.data(), default_path.data(), &output_path);
 
@@ -72,7 +72,7 @@ void FileDialog::showSingleFile(std::string_view default_path, std::string_view 
 void FileDialog::showMultipleFiles(std::string_view default_path, std::string_view filter_list)
 {
     ::nfdpathset_t path_set{};
-    Defer path_set_defer{[&path_set] { ::NFD_PathSet_Free(&path_set); }};
+    Defer          path_set_defer{[&path_set] { ::NFD_PathSet_Free(&path_set); }};
 
     auto result = ::NFD_OpenDialogMultiple(filter_list.data(), default_path.data(), &path_set);
 
@@ -87,7 +87,7 @@ void FileDialog::showMultipleFiles(std::string_view default_path, std::string_vi
 void FileDialog::showSelectFolder(std::string_view default_path)
 {
     ::nfdchar_t* output_path{nullptr};
-    Defer output_path_defer{[output_path] { std::free(output_path); }};
+    Defer        output_path_defer{[output_path] { std::free(output_path); }};
 
     auto result = ::NFD_PickFolder(default_path.data(), &output_path);
 
@@ -102,7 +102,7 @@ void FileDialog::showSelectFolder(std::string_view default_path)
 void FileDialog::showSaveFile(std::string_view default_path, std::string_view filter_list)
 {
     ::nfdchar_t* output_path{nullptr};
-    Defer output_path_defer{[output_path] { std::free(output_path); }};
+    Defer        output_path_defer{[output_path] { std::free(output_path); }};
 
     auto result = ::NFD_SaveDialog(filter_list.data(), default_path.data(), &output_path);
 

--- a/src/genesis/gui/gizmos/gizmos.cpp
+++ b/src/genesis/gui/gizmos/gizmos.cpp
@@ -72,8 +72,12 @@ Gizmos::Gizmos(const Vec2& window_pos, const Vec2& window_size, bool is_ortho)
     ImGuizmo::SetRect(window_pos.x, window_pos.y, window_size.x, window_size.y);
 }
 
-void Gizmos::draw(const Mat4& view, const Mat4& projection, Operation operation, Mode mode,
-                  Mat4* matrix, float* snap)
+void Gizmos::draw(const Mat4& view,
+                  const Mat4& projection,
+                  Operation   operation,
+                  Mode        mode,
+                  Mat4*       matrix,
+                  float*      snap)
 {
     ImGuizmo::Manipulate(value_ptr(view), value_ptr(projection), toImGuizmo(operation),
                          toImGuizmo(mode), value_ptr(*matrix), value_ptr(m_matrix_delta), snap);

--- a/src/genesis/gui/widgets/button.cpp
+++ b/src/genesis/gui/widgets/button.cpp
@@ -42,8 +42,13 @@ bool Button::call(std::string_view label, Vec2 size)
     return ImGui::Button(label.data(), toImVec2(size));
 }
 
-bool ImageButton::call(std::string_view str_id, void* texture_id, const Vec2& image_size,
-                       const Vec2& uv0, const Vec2& uv1, const Vec4& bg_col, const Vec4& tint_col)
+bool ImageButton::call(std::string_view str_id,
+                       void*            texture_id,
+                       const Vec2&      image_size,
+                       const Vec2&      uv0,
+                       const Vec2&      uv1,
+                       const Vec4&      bg_col,
+                       const Vec4&      tint_col)
 {
     return ImGui::ImageButton(str_id.data(), texture_id, toImVec2(image_size), toImVec2(uv0),
                               toImVec2(uv1), toImVec4(bg_col), toImVec4(tint_col));

--- a/src/genesis/gui/widgets/checkbox.cpp
+++ b/src/genesis/gui/widgets/checkbox.cpp
@@ -36,7 +36,7 @@
 
 namespace GE::GUI {
 
-bool Checkbox::call(std::string_view title, bool *value)
+bool Checkbox::call(std::string_view title, bool* value)
 {
     return ImGui::Checkbox(title.data(), value);
 }

--- a/src/genesis/gui/widgets/combo_box.cpp
+++ b/src/genesis/gui/widgets/combo_box.cpp
@@ -37,8 +37,11 @@
 namespace GE::GUI {
 namespace {
 
-bool beginCombo(std::string_view name, const ComboBox::Items& items, std::string_view current_item,
-                ComboBox::Flags flags, std::string_view* selected_item)
+bool beginCombo(std::string_view       name,
+                const ComboBox::Items& items,
+                std::string_view       current_item,
+                ComboBox::Flags        flags,
+                std::string_view*      selected_item)
 {
     *selected_item = current_item;
 

--- a/src/genesis/gui/widgets/drag_drop.cpp
+++ b/src/genesis/gui/widgets/drag_drop.cpp
@@ -118,8 +118,9 @@ bool DragDropPayload::validateAcceptedPayload(size_t requested_size) const
     return true;
 }
 
-DragDropSource::DragDropSource(const DragDropPayload& payload, std::string_view dragging_text,
-                               Flags flags)
+DragDropSource::DragDropSource(const DragDropPayload& payload,
+                               std::string_view       dragging_text,
+                               Flags                  flags)
 {
     setBeginFunc([&payload, dragging_text, flags] {
         if (ImGui::BeginDragDropSource(fromSourceFlags(flags))) {

--- a/src/genesis/gui/widgets/image.cpp
+++ b/src/genesis/gui/widgets/image.cpp
@@ -37,8 +37,12 @@
 
 namespace GE::GUI {
 
-void Image::call(NativeID image_id, const Vec2& size, const Vec2& uv0, const Vec2& uv1,
-                 const Vec4& tint_col, const Vec4& border_col)
+void Image::call(NativeID    image_id,
+                 const Vec2& size,
+                 const Vec2& uv0,
+                 const Vec2& uv1,
+                 const Vec4& tint_col,
+                 const Vec4& border_col)
 {
     auto* texture_id = reinterpret_cast<ImTextureID>(image_id);
     ImGui::Image(texture_id, toImVec2(size), toImVec2(uv0), toImVec2(uv1), toImVec4(tint_col),

--- a/src/genesis/gui/widgets/input_text.cpp
+++ b/src/genesis/gui/widgets/input_text.cpp
@@ -45,7 +45,7 @@ namespace GE::GUI {
 bool InputText::call(std::string_view label, std::string* output, Flags flags)
 {
     static constexpr size_t BUFFER_SIZE{1024};
-    std::vector<char> buffer(BUFFER_SIZE, 0);
+    std::vector<char>       buffer(BUFFER_SIZE, 0);
     std::ranges::copy(*output, buffer.begin());
 
     ImGui::PushID(output);

--- a/src/genesis/gui/widgets/style_var.cpp
+++ b/src/genesis/gui/widgets/style_var.cpp
@@ -175,7 +175,7 @@ StyleColor::~StyleColor()
 std::array<Vec4, StyleColor::COUNT> getStyleColors()
 {
     std::array<Vec4, StyleColor::COUNT> result{};
-    auto* colors = ImGui::GetStyle().Colors;
+    auto*                               colors = ImGui::GetStyle().Colors;
     std::transform(colors, colors + ImGuiCol_COUNT, result.begin(), &toVec4);
     return result;
 }

--- a/src/genesis/gui/widgets/value_editor.cpp
+++ b/src/genesis/gui/widgets/value_editor.cpp
@@ -38,8 +38,13 @@
 
 namespace GE::GUI {
 
-bool ValueEditor::call(std::string_view label, Vec2* value, float v_speed, float v_min, float v_max,
-                       std::string_view format, ValueEditor::Flags flags)
+bool ValueEditor::call(std::string_view   label,
+                       Vec2*              value,
+                       float              v_speed,
+                       float              v_min,
+                       float              v_max,
+                       std::string_view   format,
+                       ValueEditor::Flags flags)
 {
     ImGui::PushID(value);
     Defer defer{[] { ImGui::PopID(); }};
@@ -47,8 +52,13 @@ bool ValueEditor::call(std::string_view label, Vec2* value, float v_speed, float
                              flags);
 }
 
-bool ValueEditor::call(std::string_view label, Vec3* value, float v_speed, float v_min, float v_max,
-                       std::string_view format, Flags flags)
+bool ValueEditor::call(std::string_view label,
+                       Vec3*            value,
+                       float            v_speed,
+                       float            v_min,
+                       float            v_max,
+                       std::string_view format,
+                       Flags            flags)
 {
     ImGui::PushID(value);
     Defer defer{[] { ImGui::PopID(); }};
@@ -56,8 +66,13 @@ bool ValueEditor::call(std::string_view label, Vec3* value, float v_speed, float
                              flags);
 }
 
-bool ValueEditor::call(std::string_view label, float* value, float v_speed, float v_min,
-                       float v_max, std::string_view format, ValueEditor::Flags flags)
+bool ValueEditor::call(std::string_view   label,
+                       float*             value,
+                       float              v_speed,
+                       float              v_min,
+                       float              v_max,
+                       std::string_view   format,
+                       ValueEditor::Flags flags)
 {
     ImGui::PushID(value);
     Defer defer{[] { ImGui::PopID(); }};

--- a/src/genesis/physics2d/b2d/world.cpp
+++ b/src/genesis/physics2d/b2d/world.cpp
@@ -63,8 +63,9 @@ void World::step(Timestamp ts, int32_t sub_step_count)
     b2World_Step(m_world, ts.sec(), sub_step_count);
 }
 
-Scoped<P2D::RigidBody> World::createRigidBody(RigidBody::Type type, const Vec2& position,
-                                              float angle)
+Scoped<P2D::RigidBody> World::createRigidBody(RigidBody::Type type,
+                                              const Vec2&     position,
+                                              float           angle)
 {
     b2BodyDef body_def{b2DefaultBodyDef()};
     body_def.type = fromRigidBody(type);

--- a/src/genesis/physics2d/b2d/world.h
+++ b/src/genesis/physics2d/b2d/world.h
@@ -47,8 +47,9 @@ public:
 
     void step(Timestamp ts, int32_t sub_step_count) override;
 
-    Scoped<P2D::RigidBody> createRigidBody(RigidBody::Type type, const Vec2& position,
-                                           float angle) override;
+    Scoped<P2D::RigidBody> createRigidBody(RigidBody::Type type,
+                                           const Vec2&     position,
+                                           float           angle) override;
 
 private:
     b2WorldId m_world{b2_nullWorldId};

--- a/src/genesis/scene/entity_picker.cpp
+++ b/src/genesis/scene/entity_picker.cpp
@@ -60,7 +60,8 @@ inline bool isPositionInBounds(const Vec2& position, const Vec2& bounds)
 
 } // namespace
 
-EntityPicker::EntityPicker(Scene* scene, const Assets::Registry& assets,
+EntityPicker::EntityPicker(Scene*                      scene,
+                           const Assets::Registry&     assets,
                            const ViewProjectionCamera* camera)
     : m_scene{scene}
     , m_camera{camera}
@@ -114,8 +115,8 @@ Entity EntityPicker::getEntityByPosition(const Vec2& position)
     Vec2 inverted_position = {position.x, texture_size.y - position.y - 1};
 
     const auto* pixels = static_cast<const int32_t*>(texture);
-    size_t index = (inverted_position.y * texture_size.x) + inverted_position.x;
-    int32_t entity_id = pixels[index];
+    size_t      index = (inverted_position.y * texture_size.x) + inverted_position.x;
+    int32_t     entity_id = pixels[index];
 
     if (entity_id == ENTITY_ID_NONE) {
         return {};
@@ -167,7 +168,7 @@ void EntityPicker::renderEntityId(const Entity& entity)
 {
     auto* pipeline = m_entity_id_pipeline.get();
     auto* mesh = entity.get<SpriteComponent>().mesh.get();
-    auto mvp = m_camera->viewProjection() * parentTransform(entity) *
+    auto  mvp = m_camera->viewProjection() * parentTransform(entity) *
                entity.get<TransformComponent>().transform();
 
     auto* cmd = m_entity_id_fbo->renderer()->command();

--- a/src/genesis/scene/executor/runtime2d_executor.cpp
+++ b/src/genesis/scene/executor/runtime2d_executor.cpp
@@ -62,7 +62,7 @@ Mat4 rigidBodyTransform(const P2D::RigidBody& rigid_body)
 void updateTransform(Entity* entity, const Mat4& parent_transform)
 {
     const auto& rigid_body = *entity->get<RigidBody2DComponent>().body;
-    auto local_transform = affineInverse(parent_transform) * rigidBodyTransform(rigid_body);
+    auto        local_transform = affineInverse(parent_transform) * rigidBodyTransform(rigid_body);
     auto [translation, rotation, scale] = decompose(local_transform);
 
     auto& transform = entity->get<TransformComponent>();
@@ -117,7 +117,7 @@ void Runtime2DExecutor::initializePhysics2D()
 {
     m_scene->forEach<RigidBody2DComponent>([this](Entity& entity) {
         const auto& transform_component = entity.get<TransformComponent>();
-        auto transform = parentTransform(entity) * transform_component.transform();
+        auto        transform = parentTransform(entity) * transform_component.transform();
         auto [translation, rotation, scale] = decompose(transform);
 
         auto& rigid_body = entity.get<RigidBody2DComponent>();

--- a/src/genesis/scene/renderer/renderer_base.cpp
+++ b/src/genesis/scene/renderer/renderer_base.cpp
@@ -58,8 +58,8 @@ void RendererBase::renderEntity(GE::Renderer* renderer, Pipeline* pipeline, cons
     std::string_view entity_tag = entity.get<TagComponent>().tag;
 
     const auto& sprite = entity.get<SpriteComponent>();
-    auto* texture = sprite.texture.get();
-    auto* mesh = sprite.mesh.get();
+    auto*       texture = sprite.texture.get();
+    auto*       mesh = sprite.mesh.get();
 
     if (!isValid(entity_tag, pipeline, texture, mesh)) {
         return;
@@ -99,7 +99,7 @@ void RendererBase::renderCircleCollider2D(const Entity& entity)
     float scale_max = std::max(entity_scale.x, entity_scale.y);
 
     constexpr float COLLIDER_ANGLE{0.0f};
-    Vec2 collider_size{collider.radius * 2.0f, collider.radius * 2.0f};
+    Vec2            collider_size{collider.radius * 2.0f, collider.radius * 2.0f};
 
     auto transform =
         m_camera->viewProjection() *
@@ -126,8 +126,10 @@ void RendererBase::renderBoxCollider2D(const Entity& entity)
     m_primitives_renderer.renderSquare(transform, COLLIDER_COLOR);
 }
 
-bool RendererBase::isValid(std::string_view entity_name, Pipeline* material, Texture* texture,
-                           Mesh* mesh) const
+bool RendererBase::isValid(std::string_view entity_name,
+                           Pipeline*        material,
+                           Texture*         texture,
+                           Mesh*            mesh) const
 {
     if (material == nullptr) {
         GE_CORE_ERR("A pipeline for an entity '{}' is null", entity_name);

--- a/src/genesis/scene/renderer/wb_oit_renderer.cpp
+++ b/src/genesis/scene/renderer/wb_oit_renderer.cpp
@@ -58,8 +58,8 @@ bool isOpaque(const Entity& entity)
 
 } // namespace
 
-WeightedBlendedOITRenderer::WeightedBlendedOITRenderer(GE::Renderer* renderer,
-                                                       const Assets::Registry& assets,
+WeightedBlendedOITRenderer::WeightedBlendedOITRenderer(GE::Renderer*               renderer,
+                                                       const Assets::Registry&     assets,
                                                        const ViewProjectionCamera* camera)
     : RendererBase{renderer, camera}
 {
@@ -122,7 +122,7 @@ void WeightedBlendedOITRenderer::recreateWbOitFramebuffer(const Vec2& size)
     m_wb_oit_fbo = Framebuffer::create(config);
 }
 
-void WeightedBlendedOITRenderer::createOpaqueColorPipeline(GE::Renderer* renderer,
+void WeightedBlendedOITRenderer::createOpaqueColorPipeline(GE::Renderer*           renderer,
                                                            const Assets::Registry& assets)
 {
     auto pipeline_resource = assets.get<Assets::PipelineResource>(COLOR_PIPELINE);
@@ -141,7 +141,7 @@ void WeightedBlendedOITRenderer::createOpaqueColorPipeline(GE::Renderer* rendere
     GE_CORE_ASSERT(m_color_pipeline, "Failed to create color pipeline");
 }
 
-void WeightedBlendedOITRenderer::createAccumulationPipeline(GE::Renderer* renderer,
+void WeightedBlendedOITRenderer::createAccumulationPipeline(GE::Renderer*           renderer,
                                                             const Assets::Registry& assets)
 {
     auto pipeline_resource = assets.get<Assets::PipelineResource>(ACCUMULATION_PIPELINE);
@@ -174,7 +174,7 @@ void WeightedBlendedOITRenderer::createAccumulationPipeline(GE::Renderer* render
     GE_CORE_ASSERT(m_accumulation_pipeline, "Failed to create accumulation pipeline");
 }
 
-void WeightedBlendedOITRenderer::createComposingPipeline(GE::Renderer* renderer,
+void WeightedBlendedOITRenderer::createComposingPipeline(GE::Renderer*           renderer,
                                                          const Assets::Registry& assets)
 {
     auto pipeline_resource = assets.get<Assets::PipelineResource>(COMPOSING_PIPELINE);
@@ -207,7 +207,7 @@ void WeightedBlendedOITRenderer::renderOpaqueEntities(GE::Renderer* renderer, co
 }
 
 void WeightedBlendedOITRenderer::renderTransparentEntities(GE::Renderer* renderer,
-                                                           const Scene& scene)
+                                                           const Scene&  scene)
 {
     scene.forEach<SpriteComponent>([this, renderer](const auto& entity) {
         if (!isOpaque(entity)) {

--- a/src/genesis/scene/scene_deserializer.cpp
+++ b/src/genesis/scene/scene_deserializer.cpp
@@ -43,19 +43,19 @@
 
 #include <unordered_map>
 
-#define BIND_LOADER(mem_function) \
-    [this](auto *entity, const auto &node) { mem_function(entity, node); }
+#define BIND_LOADER(mem_function)                                                                  \
+    [this](auto* entity, const auto& node) { mem_function(entity, node); }
 
 #define ADD_LOADER(component_type) {component_type::NAME.data(), &load<component_type>}
 
-#define ADD_MEM_FN_LOADER(component_type) \
+#define ADD_MEM_FN_LOADER(component_type)                                                          \
     {component_type::NAME.data(), BIND_LOADER(load##component_type)}
 
 namespace GE::Scene {
 namespace {
 
 template<typename ComponentType>
-void load(Entity *entity, const YAML::Node &node)
+void load(Entity* entity, const YAML::Node& node)
 {
     if (!entity->has<ComponentType>()) {
         entity->add<ComponentType>();
@@ -66,12 +66,12 @@ void load(Entity *entity, const YAML::Node &node)
 
 } // namespace
 
-SceneDeserializer::SceneDeserializer(Scene *scene, Assets::Registry *assets)
+SceneDeserializer::SceneDeserializer(Scene* scene, Assets::Registry* assets)
     : m_scene{scene}
     , m_assets{assets}
 {}
 
-bool SceneDeserializer::deserialize(const std::string &config_filepath)
+bool SceneDeserializer::deserialize(const std::string& config_filepath)
 {
     m_scene_buffer.clear();
 
@@ -90,7 +90,7 @@ bool SceneDeserializer::deserialize(const std::string &config_filepath)
         if (auto entities = node["scene"]["entities"]; entities.size() > 0) {
             loadEntities(&m_scene_buffer, entities);
         }
-    } catch (const std::exception &e) {
+    } catch (const std::exception& e) {
         GE_CORE_ERR("Failed to deserialize a scene from a file '{}': '{}'", config_filepath,
                     e.what());
         return false;
@@ -101,7 +101,7 @@ bool SceneDeserializer::deserialize(const std::string &config_filepath)
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-Entity SceneDeserializer::loadEntities(Scene *scene, const YAML::Node &node)
+Entity SceneDeserializer::loadEntities(Scene* scene, const YAML::Node& node)
 {
     auto first_entity = loadEntity(scene, node[0]);
     auto last_entity = first_entity;
@@ -116,7 +116,7 @@ Entity SceneDeserializer::loadEntities(Scene *scene, const YAML::Node &node)
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-Entity SceneDeserializer::loadEntity(Scene *scene, const YAML::Node &node)
+Entity SceneDeserializer::loadEntity(Scene* scene, const YAML::Node& node)
 {
     auto entity = scene->createEntity();
 
@@ -133,9 +133,9 @@ Entity SceneDeserializer::loadEntity(Scene *scene, const YAML::Node &node)
     return entity;
 }
 
-bool SceneDeserializer::loadComponent(Entity *entity, const YAML::Node &node)
+bool SceneDeserializer::loadComponent(Entity* entity, const YAML::Node& node)
 {
-    using Loader = std::function<void(Entity *, const YAML::Node &)>;
+    using Loader = std::function<void(Entity*, const YAML::Node&)>;
 
     const std::unordered_map<std::string, Loader> LOADERS = {
         ADD_LOADER(CameraComponent),
@@ -158,7 +158,7 @@ bool SceneDeserializer::loadComponent(Entity *entity, const YAML::Node &node)
     if (auto loader = getValue(LOADERS, type); loader) {
         try {
             std::invoke(loader, entity, node);
-        } catch (const std::exception &e) {
+        } catch (const std::exception& e) {
             GE_CORE_WARN("Failed to load component '{}': '{}'", type, e.what());
         }
     }
@@ -166,14 +166,14 @@ bool SceneDeserializer::loadComponent(Entity *entity, const YAML::Node &node)
     return true;
 }
 
-void SceneDeserializer::loadMaterialComponent(Entity *entity, const YAML::Node &node)
+void SceneDeserializer::loadMaterialComponent(Entity* entity, const YAML::Node& node)
 {
     if (auto material = node.as<MaterialComponent>(); material.loadMaterial(m_assets)) {
         entity->add<MaterialComponent>() = material;
     }
 }
 
-void SceneDeserializer::loadSpriteComponent(Entity *entity, const YAML::Node &node)
+void SceneDeserializer::loadSpriteComponent(Entity* entity, const YAML::Node& node)
 {
     if (auto sprite = node.as<SpriteComponent>(); sprite.loadAll(m_assets)) {
         entity->add<SpriteComponent>() = sprite;

--- a/src/genesis/scene/scene_serializer.cpp
+++ b/src/genesis/scene/scene_serializer.cpp
@@ -43,13 +43,13 @@
 
 namespace GE::Scene {
 
-SceneSerializer::SceneSerializer(Scene *scene)
+SceneSerializer::SceneSerializer(Scene* scene)
     : m_scene{scene}
 {}
 
-bool SceneSerializer::serialize(const std::string &config_filepath)
+bool SceneSerializer::serialize(const std::string& config_filepath)
 {
-    auto serialized_scene = serializeScene();
+    auto          serialized_scene = serializeScene();
     std::ofstream fout{config_filepath};
 
     if (!fout) {
@@ -76,9 +76,9 @@ YAML::Node SceneSerializer::serializeScene()
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-void SceneSerializer::serializeEntityNode(YAML::Node *root, const EntityNode &entity)
+void SceneSerializer::serializeEntityNode(YAML::Node* root, const EntityNode& entity)
 {
-    forEachType<ComponentList>([root, &entity = entity.entity()](const auto &component) {
+    forEachType<ComponentList>([root, &entity = entity.entity()](const auto& component) {
         using Component = std::decay_t<decltype(component)>;
         auto components_node = (*root)["components"];
 
@@ -94,7 +94,7 @@ void SceneSerializer::serializeEntityNode(YAML::Node *root, const EntityNode &en
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-void SceneSerializer::serializeEntityNodes(YAML::Node *root, const EntityNode &entity)
+void SceneSerializer::serializeEntityNodes(YAML::Node* root, const EntityNode& entity)
 {
     for (auto current_entity = entity; !current_entity.isNull();
          current_entity = current_entity.nextNode()) {

--- a/src/genesis/window/SDL/window.cpp
+++ b/src/genesis/window/SDL/window.cpp
@@ -48,7 +48,7 @@ namespace {
 #ifndef GE_DISABLE_DEBUG
 const char* categoryToString(int category)
 {
-    const char* default_category = "Unknown";
+    const char*                                       default_category = "Unknown";
     static const std::unordered_map<int, const char*> cat_to_str = {
         {SDL_LOG_CATEGORY_APPLICATION, "App"}, {SDL_LOG_CATEGORY_ERROR, "Error"},
         {SDL_LOG_CATEGORY_ASSERT, "Assert"},   {SDL_LOG_CATEGORY_SYSTEM, "System"},
@@ -59,8 +59,10 @@ const char* categoryToString(int category)
     return GE::getValue(cat_to_str, category, default_category);
 }
 
-void debugCallback([[maybe_unused]] void* userdata, int category, SDL_LogPriority priority,
-                   const char* message)
+void debugCallback([[maybe_unused]] void* userdata,
+                   int                    category,
+                   SDL_LogPriority        priority,
+                   const char*            message)
 {
     const char* category_str = categoryToString(category);
     const char* pattern = "[SDL {}]: {}";
@@ -81,9 +83,9 @@ int renderAPIToWindowFlag(GE::Graphics::API api)
 {
     using API = GE::Graphics::API;
 
-    static constexpr int default_flag{0};
+    static constexpr int                default_flag{0};
     static std::unordered_map<API, int> api_to_flag = {{API::VULKAN, SDL_WINDOW_VULKAN}};
-    int flag = GE::getValue(api_to_flag, api, default_flag);
+    int                                 flag = GE::getValue(api_to_flag, api, default_flag);
 
     if (flag == default_flag) {
         GE_CORE_ERR("Failed to get SDL Window Flag: unsupported API '{}'", toString(api));
@@ -98,8 +100,8 @@ namespace GE::SDL {
 
 Window::Window(settings_t settings, Graphics::API api)
 {
-    int width = static_cast<int>(settings.size.x);
-    int height = static_cast<int>(settings.size.y);
+    int  width = static_cast<int>(settings.size.x);
+    int  height = static_cast<int>(settings.size.y);
     auto flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_SHOWN |
                  renderAPIToWindowFlag(api);
 
@@ -240,13 +242,13 @@ void Window::onMouseEvent(const SDL_Event& sdl_event)
             break;
         }
         case SDL_MOUSEBUTTONDOWN: {
-            MouseButton button = Input::fromNativeButton(sdl_event.button.button);
+            MouseButton             button = Input::fromNativeButton(sdl_event.button.button);
             MouseButtonPressedEvent event{button};
             emitEvent(&event);
             break;
         }
         case SDL_MOUSEBUTTONUP: {
-            MouseButton button = Input::fromNativeButton(sdl_event.button.button);
+            MouseButton              button = Input::fromNativeButton(sdl_event.button.button);
             MouseButtonReleasedEvent event{button};
             emitEvent(&event);
             break;
@@ -259,16 +261,16 @@ void Window::onKeyboardEvent(const SDL_Event& sdl_event)
 {
     switch (sdl_event.type) {
         case SDL_KEYDOWN: {
-            KeyCode code = Input::fromNativeKeyCode(sdl_event.key.keysym.sym);
-            KeyModFlags mod = Input::fromNativeKeyMod(sdl_event.key.keysym.mod);
-            uint32_t repeat_count = sdl_event.key.repeat;
+            KeyCode         code = Input::fromNativeKeyCode(sdl_event.key.keysym.sym);
+            KeyModFlags     mod = Input::fromNativeKeyMod(sdl_event.key.keysym.mod);
+            uint32_t        repeat_count = sdl_event.key.repeat;
             KeyPressedEvent event{code, mod, repeat_count};
             emitEvent(&event);
             break;
         }
         case SDL_KEYUP: {
-            KeyCode code = Input::fromNativeKeyCode(sdl_event.key.keysym.sym);
-            KeyModFlags mod = Input::fromNativeKeyMod(sdl_event.key.keysym.mod);
+            KeyCode          code = Input::fromNativeKeyCode(sdl_event.key.keysym.sym);
+            KeyModFlags      mod = Input::fromNativeKeyMod(sdl_event.key.keysym.mod);
             KeyReleasedEvent event{code, mod};
             emitEvent(&event);
             break;
@@ -288,13 +290,13 @@ void Window::onWindowEvent(const SDL_Event& sdl_event)
 
     switch (sdl_event.window.event) {
         case SDL_WINDOWEVENT_MOVED: {
-            Vec2 position{sdl_event.window.data1, sdl_event.window.data2};
+            Vec2             position{sdl_event.window.data1, sdl_event.window.data2};
             WindowMovedEvent event{id, position};
             emitEvent(&event);
             break;
         }
         case SDL_WINDOWEVENT_RESIZED: {
-            Vec2 size{sdl_event.window.data1, sdl_event.window.data2};
+            Vec2               size{sdl_event.window.data1, sdl_event.window.data2};
             WindowResizedEvent event{id, size};
             emitEvent(&event);
             break;

--- a/src/genesis/window/SDL/window.h
+++ b/src/genesis/window/SDL/window.h
@@ -75,7 +75,7 @@ private:
     void onKeyboardEvent(const SDL_Event& sdl_event);
     void onWindowEvent(const SDL_Event& sdl_event);
 
-    SDL_Window* m_window{nullptr};
+    SDL_Window*               m_window{nullptr};
     std::list<EventListener*> m_event_listeners;
 };
 

--- a/tests/scene/component_matchers.h
+++ b/tests/scene/component_matchers.h
@@ -38,7 +38,8 @@ namespace GE::Tests {
 
 using testing::DescribeMatcher;
 
-MATCHER_P(isTagComponent, tag,
+MATCHER_P(isTagComponent,
+          tag,
           std::string{negation ? "isn't" : "is"} + " a 'Tag' component whose tag " +
               DescribeMatcher<std::string>(tag))
 {

--- a/tests/scene/scene_deserializer_test.cpp
+++ b/tests/scene/scene_deserializer_test.cpp
@@ -70,10 +70,10 @@ protected:
 
     std::string tmpSceneFilepath() const { return GE::FS::joinPath(tmpDir.path(), "scene.yaml"); }
 
-    GE::FS::TmpDirGuard tmpDir;
-    Scene scene;
+    GE::FS::TmpDirGuard  tmpDir;
+    Scene                scene;
     GE::Assets::Registry assets;
-    SceneDeserializer deserializer{&scene, &assets};
+    SceneDeserializer    deserializer{&scene, &assets};
 };
 
 TEST_F(SceneDeserializerTest, MultipleLevelsOfEntitiesGoFirst)

--- a/tests/scene/scene_serializer_test.cpp
+++ b/tests/scene/scene_serializer_test.cpp
@@ -56,8 +56,8 @@ protected:
     std::string tmpSceneFilepath() const { return GE::FS::joinPath(tmpDir.path(), "scene.yaml"); }
 
     GE::FS::TmpDirGuard tmpDir;
-    Scene scene;
-    SceneSerializer serializer{&scene};
+    Scene               scene;
+    SceneSerializer     serializer{&scene};
 };
 
 TEST_F(SceneSerializerTest, MultipleLevelsOfEntitiesGoFirst)
@@ -95,7 +95,7 @@ TEST_F(SceneSerializerTest, MultipleLevelsOfEntitiesInTheMiddle)
 {
     {
         EntityNode parent_node_1{scene.createEntity("parent 1")};
-        auto parent_node_2 = parent_node_1.insert(scene.createEntity("parent 2"));
+        auto       parent_node_2 = parent_node_1.insert(scene.createEntity("parent 2"));
         parent_node_2.insert(scene.createEntity("parent 3"));
 
         auto child_node_1 = parent_node_2.appendChild(scene.createEntity("child 2-1"));
@@ -130,8 +130,8 @@ TEST_F(SceneSerializerTest, MultipleLevelsOfEntitiesGoLast)
 {
     {
         EntityNode parent_node_1{scene.createEntity("parent 1")};
-        auto parent_node_2 = parent_node_1.insert(scene.createEntity("parent 2"));
-        auto parent_node_3 = parent_node_2.insert(scene.createEntity("parent 3"));
+        auto       parent_node_2 = parent_node_1.insert(scene.createEntity("parent 2"));
+        auto       parent_node_3 = parent_node_2.insert(scene.createEntity("parent 3"));
 
         auto child_node_1 = parent_node_3.appendChild(scene.createEntity("child 3-1"));
         child_node_1.appendChild(scene.createEntity("child 3-2"));

--- a/tests/window/events_test.cpp
+++ b/tests/window/events_test.cpp
@@ -43,8 +43,8 @@ class KeyEventsTest: public testing::Test
 
 TEST_F(KeyEventsTest, KeyPressedEvent)
 {
-    static constexpr auto CODE{GE::KeyCode::LALT};
-    static constexpr auto MOD{GE::KeyModFlags::CAPS_LOCK_BIT};
+    static constexpr auto     CODE{GE::KeyCode::LALT};
+    static constexpr auto     MOD{GE::KeyModFlags::CAPS_LOCK_BIT};
     static constexpr uint32_t REPEAT_COUNT{49};
 
     GE::KeyPressedEvent event{CODE, MOD, REPEAT_COUNT};
@@ -236,14 +236,25 @@ class EventDispatcherTest: public ::testing::Test
 
 using EventTypeList = ::testing::Types<
     // Key events
-    GE::KeyPressedEvent, GE::KeyReleasedEvent, GE::KeyTypedEvent,
+    GE::KeyPressedEvent,
+    GE::KeyReleasedEvent,
+    GE::KeyTypedEvent,
     // Mouse events
-    GE::MouseMovedEvent, GE::MouseScrolledEvent, GE::MouseButtonPressedEvent,
+    GE::MouseMovedEvent,
+    GE::MouseScrolledEvent,
+    GE::MouseButtonPressedEvent,
     GE::MouseButtonReleasedEvent,
     // Window events
-    GE::WindowMovedEvent, GE::WindowResizedEvent, GE::WindowMinimizedEvent,
-    GE::WindowMaximizedEvent, GE::WindowRestoredEvent, GE::WindowEnteredEvent, GE::WindowLeftEvent,
-    GE::WindowFocusGainedEvent, GE::WindowFocusLostEvent, GE::WindowClosedEvent>;
+    GE::WindowMovedEvent,
+    GE::WindowResizedEvent,
+    GE::WindowMinimizedEvent,
+    GE::WindowMaximizedEvent,
+    GE::WindowRestoredEvent,
+    GE::WindowEnteredEvent,
+    GE::WindowLeftEvent,
+    GE::WindowFocusGainedEvent,
+    GE::WindowFocusLostEvent,
+    GE::WindowClosedEvent>;
 
 TYPED_TEST_SUITE(EventDispatcherTest, EventTypeList);
 


### PR DESCRIPTION
This pull request updates the `.clang-format` configuration file to refine code formatting rules, focusing on alignment, bin packing, pointer alignment, and penalties for specific formatting scenarios. These changes aim to improve code readability and enforce consistent styling across the codebase.

### Alignment Rules:
* Enabled alignment of consecutive declarations with specific options, such as allowing alignment across comments but not across empty lines. Added alignment for short case statements and changed alignment for escaped newlines to the right. ([.clang-formatL5-R17](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2L5-R17))
  
### Bin Packing Rules:
* Changed `BinPackParameters` from `true` to `OnePerLine` to enforce each parameter being on a separate line. ([.clang-formatL21-R29](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2L21-R29))

### Pointer Alignment:
* Disabled `DerivePointerAlignment`, which previously derived pointer alignment automatically. ([.clang-formatL52-R60](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2L52-R60))

### Penalty Adjustments:
* Increased the penalty for placing a return type on its own line from 60 to 80, encouraging more compact function declarations. ([.clang-formatL90-R98](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2L90-R98))